### PR TITLE
Fix Eclipse setup to work with plugin updates

### DIFF
--- a/server/eclipse.setup
+++ b/server/eclipse.setup
@@ -109,7 +109,7 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="AGFeature.feature.group"
-        versionRange="[0.3.1,0.4.0)"/>
+        versionRange="0.3.1"/>
     <repository
         url="http://kindsoftware.com/products/opensource/AutoGrader/update/"/>
   </setupTask>
@@ -118,7 +118,7 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="ie.ucd.bon.plugin.feature.group"
-        versionRange="[0.3.14,0.4.0)"/>
+        versionRange="0.3.14"/>
     <repository
         url="http://kindsoftware.com/products/opensource/BONc/update/"/>
   </setupTask>
@@ -127,10 +127,10 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="net.sf.eclipsecs.feature.group"
-        versionRange="[7.6.0,7.7.0)"/>
+        versionRange="7.6.0"/>
     <requirement
         name="com.github.sevntu.checkstyle.checks.feature.feature.group"
-        versionRange="[1.24.1,1.25.0)"/>
+        versionRange="1.24.1"/>
     <repository
         url="http://eclipse-cs.sf.net/update/"/>
   </setupTask>
@@ -139,7 +139,7 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="edu.umd.cs.findbugs.plugin.eclipse.feature.group"
-        versionRange="[3.0.1,3.1.0)"/>
+        versionRange="3.0.1"/>
     <repository
         url="http://findbugs.cs.umd.edu/eclipse"/>
   </setupTask>
@@ -148,7 +148,7 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="net.sourceforge.metrics.feature.group"
-        versionRange="[1.3.8,1.4.0)"/>
+        versionRange="1.3.8"/>
     <repository
         url="http://metrics2.sourceforge.net/update"/>
   </setupTask>
@@ -157,7 +157,7 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="org.jmlspecs.openjml.OpenJMLFeature.feature.group"
-        versionRange="[0.8.17,0.9.0)"/>
+        versionRange="0.8.17"/>
     <repository
         url="http://jmlspecs.sourceforge.net/openjml-updatesite"/>
   </setupTask>
@@ -166,13 +166,13 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="ch.acanda.eclipse.pmd.feature.feature.group"
-        versionRange="[1.10.0,1.11.0)"/>
+        versionRange="1.10.0"/>
     <requirement
         name="ch.acanda.eclipse.pmd.core.feature.feature.group"
-        versionRange="[1.10.0,1.11.0)"/>
+        versionRange="1.10.0"/>
     <requirement
         name="ch.acanda.eclipse.pmd.java.feature.feature.group"
-        versionRange="[1.10.0,1.11.0)"/>
+        versionRange="1.10.0"/>
     <repository
         url="http://www.acanda.ch/eclipse-pmd/release/latest"/>
   </setupTask>
@@ -181,10 +181,10 @@
       licenseConfirmationDisabled="true">
     <requirement
         name="org.testng.eclipse.feature.group"
-        versionRange="[6.11.0,6.12.0)"/>
+        versionRange="6.11.0"/>
     <requirement
         name="org.testng.eclipse.maven.feature.feature.group"
-        versionRange="[6.11.0,6.12.0)"/>
+        versionRange="6.11.0"/>
     <repository
         url="http://beust.com/eclipse"/>
   </setupTask>


### PR DESCRIPTION
Some plugin update sites don't serve old versions; when that happened with CheckStyle today, it broke the setup. So, I've removed the maximum version number restrictions from the setup file.