### PR TITLE
Use CI scripts to ensure immediate exit if any check fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,8 @@ before_script:
 script:
   # WARNING: If changes only occur in files outside of the checked
   # directory, the checks below will not be executed.
-  - if ${TRAVIS_BUILD_DIR}/ci/changes-in-dir client; then
-      cd "${CLIENT_DIR}";
-      npm run lint;
-      npm run build;
-      npm test;
-    fi;
+  - ${TRAVIS_BUILD_DIR}/ci/check-client
 
   # WARNING: If changes only occur in files outside of the checked
   # directory, the checks below will not be executed.
-  - if ${TRAVIS_BUILD_DIR}/ci/changes-in-dir server; then
-      cd "${SERVER_DIR}";
-      mvn verify;
-    fi;
+  - ${TRAVIS_BUILD_DIR}/ci/check-server

--- a/ci/check-client
+++ b/ci/check-client
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+# Exit early if there were no client changes.
+"${TRAVIS_BUILD_DIR}/ci/changes-in-dir" client || exit 0
+
+cd "${CLIENT_DIR}"
+npm run lint
+npm run build
+npm test

--- a/ci/check-server
+++ b/ci/check-server
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+# Exit early if there were no server changes.
+"${TRAVIS_BUILD_DIR}/ci/changes-in-dir" server || exit 0
+
+cd "${SERVER_DIR}"
+mvn verify


### PR DESCRIPTION
Rather than count on Travis' inline script execution to behave in any particular way, add external scripts to ensure we can get `set -e` behavior. This also makes the checks for sub-project changes more readable.

Tested with:
- [x] No changes to either `client` or `server`
- [x] Failing changes to `server`
- [x] Passing changes to `server`
- [x] Failing changes to `client`
- [x] Passing changes to `client`
- [x] Passing changes to both `client` and `server`

(Tests are in commits that will be added, then dropped from this branch before merging)