### PR TITLE
Add Gson to Maven configuration

### DIFF
--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -112,5 +112,10 @@
   		<artifactId>slf4j-log4j12</artifactId>
   		<version>1.7.25</version>
   	</dependency>
+  	<dependency>
+  		<groupId>org.postgresql</groupId>
+  		<artifactId>postgresql</artifactId>
+  		<version>42.1.3</version>
+  	</dependency>
   </dependencies>
 </project>

--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -117,5 +117,10 @@
   		<artifactId>postgresql</artifactId>
   		<version>42.1.3</version>
   	</dependency>
+  	<dependency>
+  		<groupId>com.google.code.gson</groupId>
+  		<artifactId>gson</artifactId>
+  		<version>2.8.1</version>
+  	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Adding Google's Gson library for JSON parsing/serialization to the Maven configuration. An extension of #84.