### PR TITLE
Fix no consensus check box

### DIFF
--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -80,7 +80,7 @@ export default function root(state: AppState = defaultState, action: any) {
         if (comments) {
             marks.comments = comments;
         }
-        if (noConsensus) {
+        if (_.isEmpty(noConsensus)) {
             marks.noConsensus = !!noConsensus;
         }
 


### PR DESCRIPTION
Closes #158.

We didn't distinguish between `false` and `null`/`undefined`. As we loop back and opt into more types, this bug class will disappear.