### PR TITLE
Asm load-transition check-transition-save support

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -369,9 +369,11 @@ public final class Main {
           Persistence.saveOrUpdate(county);
           // create default ASM for this county
           COUNTY_DASHBOARD_ASMS.put(county.identifier(), 
-                                    new CountyDashboardASM(county.identifier()));
+                                    new CountyDashboardASM(String.
+                                                           valueOf(county.identifier())));
           AUDIT_BOARD_DASHBOARD_ASMS.put(county.identifier(), 
-                                         new AuditBoardDashboardASM(county.identifier()));
+                                         new AuditBoardDashboardASM(String.
+                                                           valueOf(county.identifier())));
         } catch (final NumberFormatException e) {
           // we skip this property because it wasn't numeric
         }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AbstractStateMachine.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AbstractStateMachine.java
@@ -12,6 +12,10 @@
 
 package us.freeandfair.corla.asm;
 
+import static us.freeandfair.corla.asm.ASMEvent.AuditBoardDashboardEvent.*;
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.*;
+import static us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent.*;
+
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
@@ -176,6 +180,13 @@ public abstract class AbstractStateMachine implements Serializable {
    */
   public Set<ASMEvent> enabledASMEvents() {
     final Set<ASMEvent> result = new HashSet<ASMEvent>();
+    // skips and refreshes are always permitted
+    result.add(DOS_SKIP_EVENT);
+    result.add(DOS_REFRESH_EVENT);
+    result.add(COUNTY_SKIP_EVENT);
+    result.add(COUNTY_REFRESH_EVENT);
+    result.add(AUDIT_SKIP_EVENT);
+    result.add(AUDIT_REFRESH_EVENT);
     for (final ASMTransition t : my_transition_function) {
       if (t.startState().equals(my_current_state)) {
         result.add(t.event());
@@ -217,6 +228,16 @@ public abstract class AbstractStateMachine implements Serializable {
    */
   public ASMState stepEvent(final ASMEvent the_event)
       throws IllegalStateException {
+    // refresh and skip events are always permitted
+    if (the_event == DOS_REFRESH_EVENT ||
+        the_event == DOS_SKIP_EVENT ||
+        the_event == COUNTY_REFRESH_EVENT || 
+        the_event == COUNTY_SKIP_EVENT ||
+        the_event == AUDIT_REFRESH_EVENT || 
+        the_event == AUDIT_SKIP_EVENT) {
+      return currentState();
+    }
+                
     ASMState result = null;
     for (final ASMTransition t : my_transition_function) {
       if (t.startState().equals(my_current_state) &&

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AbstractStateMachine.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AbstractStateMachine.java
@@ -30,6 +30,8 @@ import us.freeandfair.corla.Main;
  * @author Daniel M. Zimmerman <dmz@freeandfair.us>
  * @version 0.0.1
  */
+// we'll need to investigate the complexity of this class later
+@SuppressWarnings("PMD.CyclomaticComplexity")
 public abstract class AbstractStateMachine implements Serializable {
   /**
    * The serialVersionUID.
@@ -226,6 +228,7 @@ public abstract class AbstractStateMachine implements Serializable {
    * @throws IllegalStateException is this ASM cannot transition given
    * the provided event.
    */
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   public ASMState stepEvent(final ASMEvent the_event)
       throws IllegalStateException {
     // refresh and skip events are always permitted

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AuditBoardDashboardASM.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AuditBoardDashboardASM.java
@@ -49,13 +49,13 @@ public class AuditBoardDashboardASM extends AbstractStateMachine {
    * @trace asm.county_dashboard_asm
    */
   //@ requires the_county_id != null;
-  public AuditBoardDashboardASM(final Integer the_county_id) {
+  public AuditBoardDashboardASM(final String the_county_id) {
     super(new HashSet<ASMState>(Arrays.asList(AuditBoardDashboardState.values())),
           new HashSet<ASMEvent>(Arrays.asList(AuditBoardDashboardEvent.values())),
           transitionsFor(Arrays.
                          asList(AuditBoardDashboardTransitionFunction.values())),
           AuditBoardDashboardState.AUDIT_INITIAL_STATE,
           new HashSet<ASMState>(Arrays.asList(FINAL_STATES)),
-          String.valueOf(the_county_id));
+          the_county_id);
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/CountyDashboardASM.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/CountyDashboardASM.java
@@ -51,13 +51,13 @@ public class CountyDashboardASM extends AbstractStateMachine {
    * @trace asm.county_dashboard_asm
    */
   //@ requires the_county_id != null
-  public CountyDashboardASM(final Integer the_county_id) {
+  public CountyDashboardASM(final String the_county_id) {
     super(new HashSet<ASMState>(Arrays.asList(CountyDashboardState.values())),
           new HashSet<ASMEvent>(Arrays.asList(CountyDashboardEvent.values())),
           transitionsFor(Arrays.
                          asList(CountyDashboardTransitionFunction.values())),
           CountyDashboardState.COUNTY_INITIAL_STATE,
           new HashSet<ASMState>(Arrays.asList(FINAL_STATES)),
-          String.valueOf(the_county_id));
+          the_county_id);
   } 
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.AuditBoardDashboardEvent.AUDIT_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -27,6 +29,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.persistence.Persistence;
@@ -40,7 +43,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class ACVRDownload extends AbstractEndpoint {
+public class ACVRDownload extends AbstractAuditBoardDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -55,6 +58,14 @@ public class ACVRDownload extends AbstractEndpoint {
   @Override
   public String endpointName() {
     return "/acvr";
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return AUDIT_SKIP_EVENT;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -29,6 +31,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.persistence.Persistence;
@@ -42,7 +45,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class ACVRDownloadByCounty extends AbstractEndpoint {
+public class ACVRDownloadByCounty extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -59,6 +62,14 @@ public class ACVRDownloadByCounty extends AbstractEndpoint {
     return "/acvr/county";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.AuditBoardDashboardEvent.REPORT_MARKINGS_EVENT;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,6 +37,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.persistence.Persistence;
@@ -48,7 +51,7 @@ import us.freeandfair.corla.util.SuppressFBWarnings;
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
 // TODO: consider rewriting along the same lines as CVRExportUpload
-public class ACVRUpload extends AbstractEndpoint {
+public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -65,6 +68,14 @@ public class ACVRUpload extends AbstractEndpoint {
     return "/upload-audit-cvr";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return REPORT_MARKINGS_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractAuditBoardDashboardEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractAuditBoardDashboardEndpoint.java
@@ -1,0 +1,36 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 12, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @creator Joe Kiniry <kiniry@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.endpoint;
+
+import us.freeandfair.corla.asm.AuditBoardDashboardASM;
+
+/**
+ * Functionality that spans endpoints on the Audit Board Dashboard.
+ */
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public abstract class AbstractAuditBoardDashboardEndpoint extends AbstractEndpoint {
+  /**
+   * @return County authorization is required for these endpoints.
+   */
+  @Override
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.COUNTY;
+  }
+  
+  /**
+   * @return subclasses of this endpoint use the Department of State ASM.
+   */
+  @Override
+  protected Class<AuditBoardDashboardASM> asmClass() {
+    return AuditBoardDashboardASM.class;
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractAuditBoardDashboardEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractAuditBoardDashboardEndpoint.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import spark.Request;
+
 import us.freeandfair.corla.asm.AuditBoardDashboardASM;
 
 /**
@@ -32,5 +34,17 @@ public abstract class AbstractAuditBoardDashboardEndpoint extends AbstractEndpoi
   @Override
   protected Class<AuditBoardDashboardASM> asmClass() {
     return AuditBoardDashboardASM.class;
+  }
+  
+  /**
+   * Gets the ASM identity for the specified request.
+   * 
+   * @param the_request The request.
+   * @return the county ID of the authenticated county.
+   */
+  @Override
+  protected String asmIdentity(final Request the_request) {
+    return String.valueOf(Authentication.
+                          authenticatedCounty(the_request).identifier());
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractCountyDashboardEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractCountyDashboardEndpoint.java
@@ -5,32 +5,32 @@
  * @created Aug 12, 2017
  * @copyright 2017 Free & Fair
  * @license GNU General Public License 3.0
- * @creator Joe Kiniry <kiniry@freeandfair.us>
+ * @created Joe Kiniry <kiniry@freeandfair.us>
  * @description A system to assist in conducting statewide risk-limiting audits.
  */
 
 package us.freeandfair.corla.endpoint;
 
-import us.freeandfair.corla.asm.DoSDashboardASM;
+import us.freeandfair.corla.asm.CountyDashboardASM;
 
 /**
  * Functionality that spans endpoints on the Department of State Dashboard.
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public abstract class AbstractDoSEndpoint extends AbstractEndpoint {
+public abstract class AbstractCountyDashboardEndpoint extends AbstractEndpoint {
   /**
    * @return State authorization is required for these endpoints.
    */
   @Override
   public AuthorizationType requiredAuthorization() {
-    return AuthorizationType.STATE;
+    return AuthorizationType.COUNTY;
   }
   
   /**
    * @return subclasses of this endpoint use the Department of State ASM.
    */
   @Override
-  protected Class<DoSDashboardASM> asmClass() {
-    return DoSDashboardASM.class;
+  protected Class<CountyDashboardASM> asmClass() {
+    return CountyDashboardASM.class;
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractCountyDashboardEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractCountyDashboardEndpoint.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import spark.Request;
+
 import us.freeandfair.corla.asm.CountyDashboardASM;
 
 /**
@@ -32,5 +34,17 @@ public abstract class AbstractCountyDashboardEndpoint extends AbstractEndpoint {
   @Override
   protected Class<CountyDashboardASM> asmClass() {
     return CountyDashboardASM.class;
+  }
+  
+  /**
+   * Gets the ASM identity for the specified request.
+   * 
+   * @param the_request The request.
+   * @return the county ID of the authenticated county.
+   */
+  @Override
+  protected String asmIdentity(final Request the_request) {
+    return String.valueOf(Authentication.
+                          authenticatedCounty(the_request).identifier());
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSDashboardEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSDashboardEndpoint.java
@@ -37,10 +37,8 @@ public abstract class AbstractDoSDashboardEndpoint extends AbstractEndpoint {
   }
   
   /**
-   * Returns null, because the DoS dashboard is a singleton.
-   * 
-   * @param the_request The request, ignored.
-   * @return null.
+   * @param the_request the ignored request.
+   * @return null because the DoS dashboard is a singleton.
    */
   @Override
   // this method is definitely not empty, but PMD thinks it is

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSDashboardEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSDashboardEndpoint.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import spark.Request;
+
 import us.freeandfair.corla.asm.DoSDashboardASM;
 
 /**
@@ -32,5 +34,18 @@ public abstract class AbstractDoSDashboardEndpoint extends AbstractEndpoint {
   @Override
   protected Class<DoSDashboardASM> asmClass() {
     return DoSDashboardASM.class;
+  }
+  
+  /**
+   * Returns null, because the DoS dashboard is a singleton.
+   * 
+   * @param the_request The request, ignored.
+   * @return null.
+   */
+  @Override
+  // this method is definitely not empty, but PMD thinks it is
+  @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+  protected String asmIdentity(final Request the_request) {
+    return null;
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSDashboardEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSDashboardEndpoint.java
@@ -1,0 +1,36 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 12, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @creator Joe Kiniry <kiniry@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.endpoint;
+
+import us.freeandfair.corla.asm.DoSDashboardASM;
+
+/**
+ * Functionality that spans endpoints on the Department of State Dashboard.
+ */
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public abstract class AbstractDoSDashboardEndpoint extends AbstractEndpoint {
+  /**
+   * @return State authorization is required for these endpoints.
+   */
+  @Override
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.STATE;
+  }
+  
+  /**
+   * @return subclasses of this endpoint use the Department of State ASM.
+   */
+  @Override
+  protected Class<DoSDashboardASM> asmClass() {
+    return DoSDashboardASM.class;
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractDoSEndpoint.java
@@ -1,0 +1,36 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 12, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @creator Joe Kiniry <kiniry@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.endpoint;
+
+import us.freeandfair.corla.asm.DoSDashboardASM;
+
+/**
+ * Functionality that spans endpoints on the Department of State Dashboard.
+ */
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public abstract class AbstractDoSEndpoint extends AbstractEndpoint {
+  /**
+   * @return State authorization is required for these endpoints.
+   */
+  @Override
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.STATE;
+  }
+  
+  /**
+   * @return subclasses of this endpoint use the Department of State ASM.
+   */
+  @Override
+  protected Class<DoSDashboardASM> asmClass() {
+    return DoSDashboardASM.class;
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -28,7 +28,6 @@ import spark.Spark;
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.asm.AbstractStateMachine;
-import us.freeandfair.corla.asm.DoSDashboardASM;
 import us.freeandfair.corla.asm.PersistentASMState;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 import us.freeandfair.corla.persistence.Persistence;
@@ -111,6 +110,7 @@ public abstract class AbstractEndpoint implements Endpoint {
 
   /**
    * Indicate that the operation completed successfully.
+   * @param the_response the HTTP response.
    */
   public void ok(final Response the_response) {
     the_response.status(HttpStatus.OK_200);    
@@ -118,97 +118,119 @@ public abstract class AbstractEndpoint implements Endpoint {
   
   /**
    * Indicate and log that the operation completed successfully.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
-  public void ok(final Response the_response, final String the_log_message) {
+  public void ok(final Response the_response, 
+                 final String the_body) {
     the_response.status(HttpStatus.OK_200);
-    Main.LOGGER.error("successful operation 200: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("successful operation 200 on endpoint " + endpointName());
+    my_endpoint_result = the_body;
   }
 
   /**
    * Indicate the client has violated an invariant or precondition relating data
    * to the endpoint in question. E.g., a digest is incorrect with regards to
    * the file that it summarizes.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void invariantViolation(final Response the_response, 
-                                 final String the_log_message) {
+                                 final String the_body) {
     the_response.status(HttpStatus.BAD_REQUEST_400);
-    Main.LOGGER.error("invariant violation 400: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("invariant violation 400 on endpoint " + endpointName());
+    my_endpoint_result = the_body;
   }
   
   /**
    * Indicate that the client is not authorized to perform the requested action.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void unauthorized(final Response the_response, 
-                           final String the_log_message) {
+                           final String the_body) {
     the_response.status(HttpStatus.UNAUTHORIZED_401);
-    Main.LOGGER.error("unauthorized access 401: " + the_log_message);
+    Main.LOGGER.error("unauthorized access 401 on endpoint " + endpointName());
     // TODO: should we halt() the endpoint execution here and simply send 
     // the response
-    my_endpoint_result = the_log_message;
+    my_endpoint_result = the_body;
   }
 
   /**
    * Indicate the client cannot perform the requested action because it violates
    * the server's state machine.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void illegalTransition(final Response the_response, 
-                                final String the_log_message) {
+                                final String the_body) {
     the_response.status(HttpStatus.FORBIDDEN_403);
-    Main.LOGGER.error("illegal transition attempt 403: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("illegal transition attempt 403 on endpoint " + 
+        endpointName());
+    my_endpoint_result = the_body;
   }
 
   /**
    * Indicate that some data was not found.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void dataNotFound(final Response the_response, 
-                           final String the_log_message) {
+                           final String the_body) {
     the_response.status(HttpStatus.NOT_FOUND_404);
-    Main.LOGGER.error("server error 404: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("server error 404 on endpoint " + endpointName());
+    my_endpoint_result = the_body;
   }
 
   /**
    * Indicate that the type/shape of data the client provided is ill-formed.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void badDataType(final Response the_response, 
-                          final String the_log_message) {
+                          final String the_body) {
     the_response.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
-    Main.LOGGER.error("bad data type from client 415: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("bad data type from client 415 on endpoint " + 
+        endpointName());
+    my_endpoint_result = the_body;
   }
 
   /**
    * Indicate that data that the client provided is ill-formed.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void badDataContents(final Response the_response, 
-                              final String the_log_message) {
+                              final String the_body) {
     the_response.status(HttpStatus.UNPROCESSABLE_ENTITY_422);
-    Main.LOGGER.error("bad data from client 422: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("bad data from client 422 on endpoint " + endpointName());
+    my_endpoint_result = the_body;
   }
 
   /**
    * Indicate that an internal server error has taken place.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void serverError(final Response the_response, 
-                          final String the_log_message) {
+                          final String the_body) {
     the_response.status(HttpStatus.INTERNAL_SERVER_ERROR_500);
-    Main.LOGGER.error("server error 500: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("server error 500 on endpoint " + endpointName());
+    my_endpoint_result = the_body;
   }
 
   /**
    * Indicate that the server is temporarily unavailable. This is typically due
    * to a long-lived transaction running or server maintenance.
+   * @param the_response the HTTP response.
+   * @param the_body the body of the HTTP response.
    */
   public void serverUnavailable(final Response the_response, 
-                                final String the_log_message) {
+                                final String the_body) {
     the_response.status(HttpStatus.SERVICE_UNAVAILABLE_503);
-    Main.LOGGER.error("server temporarily unavailable 503: " + the_log_message);
-    my_endpoint_result = the_log_message;
+    Main.LOGGER.error("server temporarily unavailable 503 on endpoint " + 
+        endpointName());
+    my_endpoint_result = the_body;
   }
 
   /**
@@ -223,8 +245,9 @@ public abstract class AbstractEndpoint implements Endpoint {
     ok(the_response);
 
     // If this is the root endpoint, just return.
-    if (endpointName().equals("/"))
+    if ("/".equals(endpointName())) {
       return;
+    }
 
     // Start a transaction, if the database is functioning; otherwise abort
     if (Persistence.hasDB()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -229,6 +229,10 @@ public abstract class AbstractEndpoint implements Endpoint {
     // Presume everything goes ok.
     ok(the_response);
 
+    // If this is the root endpoint, just return.
+    if (endpointName().equals("/"))
+      return;
+
     // Start a transaction, if the database is functioning; otherwise abort
     if (Persistence.hasDB()) {
       Persistence.beginTransaction(); 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -124,6 +124,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void ok(final Response the_response, 
                  final String the_body) {
     the_response.status(HttpStatus.OK_200);
+    the_response.body(the_body);
     Main.LOGGER.error("successful operation 200 on endpoint " + endpointName());
     my_endpoint_result = the_body;
   }
@@ -138,6 +139,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void invariantViolation(final Response the_response, 
                                  final String the_body) {
     the_response.status(HttpStatus.BAD_REQUEST_400);
+    the_response.body(the_body);
     Main.LOGGER.error("invariant violation 400 on endpoint " + endpointName());
     my_endpoint_result = the_body;
   }
@@ -150,6 +152,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void unauthorized(final Response the_response, 
                            final String the_body) {
     the_response.status(HttpStatus.UNAUTHORIZED_401);
+    the_response.body(the_body);
     Main.LOGGER.error("unauthorized access 401 on endpoint " + endpointName());
     // TODO: should we halt() the endpoint execution here and simply send 
     // the response
@@ -165,6 +168,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void illegalTransition(final Response the_response, 
                                 final String the_body) {
     the_response.status(HttpStatus.FORBIDDEN_403);
+    the_response.body(the_body);
     Main.LOGGER.error("illegal transition attempt 403 on endpoint " + 
         endpointName());
     my_endpoint_result = the_body;
@@ -178,6 +182,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void dataNotFound(final Response the_response, 
                            final String the_body) {
     the_response.status(HttpStatus.NOT_FOUND_404);
+    the_response.body(the_body);
     Main.LOGGER.error("server error 404 on endpoint " + endpointName());
     my_endpoint_result = the_body;
   }
@@ -190,6 +195,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void badDataType(final Response the_response, 
                           final String the_body) {
     the_response.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
+    the_response.body(the_body);
     Main.LOGGER.error("bad data type from client 415 on endpoint " + 
         endpointName());
     my_endpoint_result = the_body;
@@ -203,6 +209,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void badDataContents(final Response the_response, 
                               final String the_body) {
     the_response.status(HttpStatus.UNPROCESSABLE_ENTITY_422);
+    the_response.body(the_body);
     Main.LOGGER.error("bad data from client 422 on endpoint " + endpointName());
     my_endpoint_result = the_body;
   }
@@ -215,6 +222,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void serverError(final Response the_response, 
                           final String the_body) {
     the_response.status(HttpStatus.INTERNAL_SERVER_ERROR_500);
+    the_response.body(the_body);
     Main.LOGGER.error("server error 500 on endpoint " + endpointName());
     my_endpoint_result = the_body;
   }
@@ -228,6 +236,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void serverUnavailable(final Response the_response, 
                                 final String the_body) {
     the_response.status(HttpStatus.SERVICE_UNAVAILABLE_503);
+    the_response.body(the_body);
     Main.LOGGER.error("server temporarily unavailable 503 on endpoint " + 
         endpointName());
     my_endpoint_result = the_body;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -119,16 +119,9 @@ public abstract class AbstractEndpoint implements Endpoint {
   /**
    * Indicate and log that the operation completed successfully.
    */
-<<<<<<< HEAD
-  public void unauthorized(final Response the_response, final String the_log_message) {
-    the_response.status(HttpStatus.UNAUTHORIZED_401);
-    Main.LOGGER.error("unauthorized access 401: " + the_log_message);
-    // TODO: should we halt() the endpoint execution here and simply send the response
-=======
   public void ok(final Response the_response, final String the_log_message) {
     the_response.status(HttpStatus.OK_200);
     Main.LOGGER.error("successful operation 200: " + the_log_message);
->>>>>>> Implemented automatic ASM load, transition, and save for endpoints.
     my_endpoint_result = the_log_message;
   }
 
@@ -262,12 +255,9 @@ public abstract class AbstractEndpoint implements Endpoint {
    * themselves).
    */
   public void after(final Request the_request, final Response the_response) {
-<<<<<<< HEAD
-=======
     // first, take the transition for this endpoint in the ASM and save it to the DB
     transitionAndSaveASM();
     // then finish the transaction
->>>>>>> Implemented automatic ASM load, transition, and save for endpoints.
     if (Persistence.isTransactionRunning()) {
       try {
         Persistence.commitTransaction();
@@ -336,10 +326,8 @@ public abstract class AbstractEndpoint implements Endpoint {
         result = county || state;
         break;
           
-<<<<<<< HEAD
-=======
       case NONE:
->>>>>>> Implemented automatic ASM load, transition, and save for endpoints.
+
       default:
     }
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -181,8 +181,16 @@ public abstract class AbstractEndpoint implements Endpoint {
 
     // If the client is unauthorized, then indicate such and redirect.
 
-    // Check that the user is authorized for this endpoint
-    if (!checkAuthorization(the_request, requiredAuthorization())) {
+    // Determine what type of authentication is required for this endpoint
+    // null = unrestricted endpoint (such as "/")
+    // TODO: should this be determined by asking the endpoint, or by asking the ASM?
+    // TODO: should we have another enum type (STATE/COUNTY/NONE) for this? 
+    // TODO: should we enable state admins to masquerade as county admins?
+    final AdministratorType admin_type = AdministratorType.STATE; // for now.
+    
+    // Check that the user is appropriately authenticated
+    if (admin_type != null && 
+        !Authentication.isAuthenticatedAs(the_request, admin_type)) {
       unauthorized(the_response,
                    "client not authorized to perform this action");
       halt(the_response);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -96,8 +96,9 @@ public abstract class AbstractEndpoint implements Endpoint {
    */
   protected void loadAndCheckASM(final Request the_request,
                                  final Response the_response) {
-    // get the state of the dashboard
+    // get the state of the ASM
     if (asmClass() == null) {
+      // there is no ASM for this endpoint
       return;
     }
     final String asm_id = asmIdentity(the_request);
@@ -133,6 +134,10 @@ public abstract class AbstractEndpoint implements Endpoint {
    * Save the ASM back to the database.
    */
   protected void transitionAndSaveASM()  {
+    if (my_asm == null) {
+      // there is no ASM for this endpoint
+      return;
+    }
     my_asm.stepEvent(endpointEvent());
     my_persistent_asm_state.updateFrom(my_asm);
     Persistence.saveOrUpdate(my_persistent_asm_state);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
@@ -17,7 +17,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.asm.ASMEvent;
-import us.freeandfair.corla.asm.CountyDashboardASM;
+import us.freeandfair.corla.asm.AbstractStateMachine;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 
 /**
@@ -40,8 +40,8 @@ public class AuthenticateCountyAdministrator extends AbstractEndpoint {
    * @return this endpoint uses the Department of State ASM.
    */
   @Override
-  protected Class<CountyDashboardASM> asmClass() {
-    return CountyDashboardASM.class;
+  protected Class<AbstractStateMachine> asmClass() {
+    return null;
   }
 
   /**
@@ -76,8 +76,7 @@ public class AuthenticateCountyAdministrator extends AbstractEndpoint {
    */
   @Override
   protected String asmIdentity(final Request the_request) {
-    return String.valueOf(Authentication.
-                          authenticatedCounty(the_request).identifier());
+    return null;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
@@ -11,9 +11,12 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import spark.Request;
 import spark.Response;
 
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 
 /**
@@ -23,7 +26,7 @@ import us.freeandfair.corla.model.Administrator.AdministratorType;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class AuthenticateCountyAdministrator extends AbstractEndpoint {
+public class AuthenticateCountyAdministrator extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -40,6 +43,14 @@ public class AuthenticateCountyAdministrator extends AbstractEndpoint {
     return "/auth-county-admin";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * Attempts to authenticate a county administrator; if the authentication is
    * successful, authentication data is added to the session.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
@@ -17,6 +17,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.asm.ASMEvent;
+import us.freeandfair.corla.asm.CountyDashboardASM;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 
 /**
@@ -26,7 +27,23 @@ import us.freeandfair.corla.model.Administrator.AdministratorType;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class AuthenticateCountyAdministrator extends AbstractCountyDashboardEndpoint {
+public class AuthenticateCountyAdministrator extends AbstractEndpoint {
+  /**
+   * @return no authorization is required for this endpoints.
+   */
+  @Override
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.NONE;
+  }
+  
+  /**
+   * @return this endpoint uses the Department of State ASM.
+   */
+  @Override
+  protected Class<CountyDashboardASM> asmClass() {
+    return CountyDashboardASM.class;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -51,6 +68,18 @@ public class AuthenticateCountyAdministrator extends AbstractCountyDashboardEndp
     return COUNTY_SKIP_EVENT;
   }
   
+  /**
+   * Gets the ASM identity for the specified request.
+   * 
+   * @param the_request The request.
+   * @return the county ID of the authenticated county.
+   */
+  @Override
+  protected String asmIdentity(final Request the_request) {
+    return String.valueOf(Authentication.
+                          authenticatedCounty(the_request).identifier());
+  }
+
   /**
    * Attempts to authenticate a county administrator; if the authentication is
    * successful, authentication data is added to the session.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
@@ -18,6 +18,7 @@ import spark.Response;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.asm.ASMEvent;
+import us.freeandfair.corla.asm.DoSDashboardASM;
 import us.freeandfair.corla.json.ServerASMResponse;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 
@@ -28,7 +29,23 @@ import us.freeandfair.corla.model.Administrator.AdministratorType;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class AuthenticateStateAdministrator extends AbstractDoSDashboardEndpoint {
+public class AuthenticateStateAdministrator extends AbstractEndpoint {
+  /**
+   * @return no authorization is required for this endpoints.
+   */
+  @Override
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.NONE;
+  }
+  
+  /**
+   * @return this endpoint uses the Department of State ASM.
+   */
+  @Override
+  protected Class<DoSDashboardASM> asmClass() {
+    return DoSDashboardASM.class;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -53,6 +70,17 @@ public class AuthenticateStateAdministrator extends AbstractDoSDashboardEndpoint
     return AUTHENTICATE_STATE_ADMINISTRATOR_EVENT;
   }
   
+  /**
+   * @param the_request the ignored request.
+   * @return null because the DoS dashboard is a singleton.
+   */
+  @Override
+  // this method is definitely not empty, but PMD thinks it is
+  @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+  protected String asmIdentity(final Request the_request) {
+    return null;
+  }
+
   /**
    * Attempts to authenticate a state administrator; if the authentication is
    * successful, authentication data is added to the session.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
@@ -18,7 +18,6 @@ import spark.Response;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.asm.ASMEvent;
-import us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent;
 import us.freeandfair.corla.json.ServerASMResponse;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 
@@ -72,7 +71,7 @@ public class AuthenticateStateAdministrator extends AbstractDoSDashboardEndpoint
     }
 
     // Take the transition triggered by this successful authentication.
-    Main.dosDashboardASM().stepEvent(DoSDashboardEvent.AUTHENTICATE_STATE_ADMINISTRATOR_EVENT);
+    Main.dosDashboardASM().stepEvent(AUTHENTICATE_STATE_ADMINISTRATOR_EVENT);
 
     // Build the ASM server response.
     final ServerASMResponse asm_response =

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
@@ -11,10 +11,13 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent.AUTHENTICATE_STATE_ADMINISTRATOR_EVENT;
+
 import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent;
 import us.freeandfair.corla.json.ServerASMResponse;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
@@ -26,7 +29,7 @@ import us.freeandfair.corla.model.Administrator.AdministratorType;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class AuthenticateStateAdministrator extends AbstractEndpoint {
+public class AuthenticateStateAdministrator extends AbstractDoSDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -43,6 +46,14 @@ public class AuthenticateStateAdministrator extends AbstractEndpoint {
     return "/auth-state-admin";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return AUTHENTICATE_STATE_ADMINISTRATOR_EVENT;
+  }
+  
   /**
    * Attempts to authenticate a state administrator; if the authentication is
    * successful, authentication data is added to the session.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
@@ -18,7 +18,7 @@ import spark.Response;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.asm.ASMEvent;
-import us.freeandfair.corla.asm.DoSDashboardASM;
+import us.freeandfair.corla.asm.AbstractStateMachine;
 import us.freeandfair.corla.json.ServerASMResponse;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 
@@ -42,8 +42,8 @@ public class AuthenticateStateAdministrator extends AbstractEndpoint {
    * @return this endpoint uses the Department of State ASM.
    */
   @Override
-  protected Class<DoSDashboardASM> asmClass() {
-    return DoSDashboardASM.class;
+  protected Class<AbstractStateMachine> asmClass() {
+    return null;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -20,6 +22,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.BallotManifestInfo;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.util.SparkHelper;
@@ -31,7 +34,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class BallotManifestDownload extends AbstractEndpoint {
+public class BallotManifestDownload extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -48,6 +51,14 @@ public class BallotManifestDownload extends AbstractEndpoint {
     return "/ballot-manifest";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -34,6 +36,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.BallotManifestInfo;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.util.SparkHelper;
@@ -45,7 +48,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class BallotManifestDownloadByCounty extends AbstractEndpoint {
+public class BallotManifestDownloadByCounty extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -62,6 +65,14 @@ public class BallotManifestDownloadByCounty extends AbstractEndpoint {
     return "/ballot-manifest/county";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestUpload.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.UPLOAD_BALLOT_MANIFEST_EVENT;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -43,6 +45,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.csv.BallotManifestParser;
 import us.freeandfair.corla.csv.ColoradoBallotManifestParser;
 import us.freeandfair.corla.model.BallotManifestInfo;
@@ -63,7 +66,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.ExcessiveImports"})
-public class BallotManifestUpload extends AbstractEndpoint {
+public class BallotManifestUpload extends AbstractCountyDashboardEndpoint {
   /**
    * The upload buffer size, in bytes.
    */
@@ -90,6 +93,14 @@ public class BallotManifestUpload extends AbstractEndpoint {
     return "/upload-ballot-manifest";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return UPLOAD_BALLOT_MANIFEST_EVENT;
+  }
+  
   /**
    * Attempts to save the specified file in the database.
    * 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -27,6 +29,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.persistence.Persistence;
@@ -40,7 +43,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class CVRDownload extends AbstractEndpoint {
+public class CVRDownload extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -57,6 +60,14 @@ public class CVRDownload extends AbstractEndpoint {
     return "/cvr";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -29,6 +31,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.persistence.Persistence;
@@ -42,7 +45,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class CVRDownloadByCounty extends AbstractEndpoint {
+public class CVRDownloadByCounty extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -58,7 +61,15 @@ public class CVRDownloadByCounty extends AbstractEndpoint {
   public String endpointName() {
     return "/cvr/county";
   }
-
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
@@ -11,10 +11,13 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.persistence.Persistence;
 
@@ -25,7 +28,7 @@ import us.freeandfair.corla.persistence.Persistence;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class CVRDownloadByID extends AbstractEndpoint {
+public class CVRDownloadByID extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -40,6 +43,14 @@ public class CVRDownloadByID extends AbstractEndpoint {
   @Override
   public String endpointName() {
     return "/cvr/id/:id";
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportUpload.java
@@ -16,6 +16,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.UPLOAD_CVRS_EVENT;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -48,6 +50,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.csv.CVRExportParser;
 import us.freeandfair.corla.csv.DominionCVRExportParser;
 import us.freeandfair.corla.model.CastVoteRecord;
@@ -69,7 +72,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.ExcessiveImports"})
-public class CVRExportUpload extends AbstractEndpoint {
+public class CVRExportUpload extends AbstractCountyDashboardEndpoint {
   /**
    * The upload buffer size, in bytes.
    */
@@ -94,6 +97,14 @@ public class CVRExportUpload extends AbstractEndpoint {
   @Override
   public String endpointName() {
     return "/upload-cvr-export";
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return UPLOAD_CVRS_EVENT;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -22,6 +24,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.Contest;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.util.SparkHelper;
@@ -33,7 +36,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class ContestDownload extends AbstractEndpoint {
+public class ContestDownload extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -50,6 +53,14 @@ public class ContestDownload extends AbstractEndpoint {
     return "/contest";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,6 +27,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.Contest;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.persistence.Persistence;
@@ -38,7 +41,7 @@ import us.freeandfair.corla.util.SparkHelper;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class ContestDownloadByCounty extends AbstractEndpoint {
+public class ContestDownloadByCounty extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -55,6 +58,14 @@ public class ContestDownloadByCounty extends AbstractEndpoint {
     return "/contest/county";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
@@ -11,10 +11,13 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_SKIP_EVENT;
+
 import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.Contest;
 import us.freeandfair.corla.persistence.Persistence;
 
@@ -25,7 +28,7 @@ import us.freeandfair.corla.persistence.Persistence;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class ContestDownloadByID extends AbstractEndpoint {
+public class ContestDownloadByID extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -42,6 +45,14 @@ public class ContestDownloadByID extends AbstractEndpoint {
     return "/contest/id/:id";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_SKIP_EVENT;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
@@ -11,12 +11,15 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.COUNTY_REFRESH_EVENT;
+
 import javax.persistence.PersistenceException;
 
 import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.json.CountyDashboardRefreshResponse;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.query.CountyDashboardQueries;
@@ -29,7 +32,7 @@ import us.freeandfair.corla.query.CountyDashboardQueries;
  */
 // endpoints don't need constructors
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class CountyDashboardRefresh extends AbstractEndpoint {
+public class CountyDashboardRefresh extends AbstractCountyDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -46,6 +49,14 @@ public class CountyDashboardRefresh extends AbstractEndpoint {
     return "/county-dashboard";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return COUNTY_REFRESH_EVENT;
+  }
+  
   /**
    * Provides information about the DoS dashboard.
    * 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
@@ -11,12 +11,15 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent.DOS_REFRESH_EVENT;
+
 import javax.persistence.PersistenceException;
 
 import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.json.DoSDashboardRefreshResponse;
 import us.freeandfair.corla.query.DepartmentOfStateDashboardQueries;
 
@@ -28,7 +31,7 @@ import us.freeandfair.corla.query.DepartmentOfStateDashboardQueries;
  */
 // endpoints don't need constructors
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class DoSDashboardRefresh extends AbstractEndpoint {
+public class DoSDashboardRefresh extends AbstractDoSDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -45,6 +48,14 @@ public class DoSDashboardRefresh extends AbstractEndpoint {
     return "/dos-dashboard";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return DOS_REFRESH_EVENT;
+  }
+  
   /**
    * Provides information about the DoS dashboard.
    * 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
@@ -19,11 +19,16 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
+import us.freeandfair.corla.asm.DoSDashboardASM;
+import us.freeandfair.corla.asm.PersistentASMState;
+import static us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent.ESTABLISH_RISK_LIMIT_FOR_COMPARISON_AUDITS_EVENT;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 import us.freeandfair.corla.model.AuditStage;
 import us.freeandfair.corla.model.DepartmentOfStateDashboard;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.DepartmentOfStateDashboardQueries;
+import us.freeandfair.corla.query.PersistentASMStateQueries;
 
 /**
  * The endpoint for establishing the risk limit for comparison audits.
@@ -32,7 +37,7 @@ import us.freeandfair.corla.query.DepartmentOfStateDashboardQueries;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class RiskLimitForComparisonAudits extends AbstractEndpoint {
+public class RiskLimitForComparisonAudits extends AbstractDoSEndpoint {
   /**
    * The "risk limit" parameter.
    */
@@ -53,7 +58,12 @@ public class RiskLimitForComparisonAudits extends AbstractEndpoint {
   public String endpointName() {
     return "/risk-limit-comp-audits";
   }
-
+  
+  @Override
+  protected ASMEvent endpointEvent() {
+    return ESTABLISH_RISK_LIMIT_FOR_COMPARISON_AUDITS_EVENT;
+  }
+  
   /**
    * Attempts to set the risk limit for comparison audits. The risk limit
    * should be provided as a decimal number (i.e., 0.10 for 10%). 
@@ -65,38 +75,30 @@ public class RiskLimitForComparisonAudits extends AbstractEndpoint {
    */
   @Override
   public String endpoint(final Request the_request, final Response the_response) {
+    // the before() action automatically checks that the server is ready,
+    // starts a transaction, loads the ASM, checks to see if this endpoint is 
+    // permitted given the current state of the ASM, 
     ok(the_response, "Risk limit set");
     BigDecimal risk_limit = null;
-    
-    if (Authentication.isAuthenticatedAs(the_request, AdministratorType.STATE)) {
-      // see if a valid risk limit was passed in
-      risk_limit = parseRiskLimit(the_request.queryParams(RISK_LIMIT));
-
-      if (risk_limit == null) {
-        Main.LOGGER.info("attempt to set an invalid risk limit");
-        invariantViolation(the_response, "Invalid risk limit specified");
-      } else {
-        final DepartmentOfStateDashboard dosd = DepartmentOfStateDashboardQueries.get();
-        if (dosd != null && dosd.auditStage() == AuditStage.PRE_AUDIT) {
-          dosd.setRiskLimitForComparisonAudits(risk_limit);
-          try {
-            Persistence.saveOrUpdate(dosd);
-            Main.LOGGER.info("risk limit for comparison audits set to " + risk_limit);
-          } catch (final PersistenceException e) {
-            Main.LOGGER.error("unable to set risk limit for comparison audits: " + e);
-          }
-        } else if (dosd == null) {
-          serverError(the_response, "could not get department of state dashboard"); 
-        } else {
-          Main.LOGGER.info("attempt to set the risk limit for comparision audits " +
-                           "in incorrect state " + dosd.auditStage());
-          illegalTransition(the_response, "Attempt to set the risk limit in incorrect state");
-        }
-      } 
+    // see if a valid risk limit was passed in
+    risk_limit = parseRiskLimit(the_request.queryParams(RISK_LIMIT));
+    if (risk_limit == null) {
+      Main.LOGGER.info("attempt to set an invalid risk limit");
+      invariantViolation(the_response, "Invalid risk limit specified");
     } else {
-      Main.LOGGER.info("unauthorized attempt to set the risk limit for comparison audits");
-      unauthorized(the_response, "Unauthorized attempt to set the risk limit"); 
-    }
+      final DepartmentOfStateDashboard dosd = DepartmentOfStateDashboardQueries.get();
+      if (dosd != null) {
+        dosd.setRiskLimitForComparisonAudits(risk_limit);
+        try {
+          Persistence.saveOrUpdate(dosd);
+          Main.LOGGER.info("risk limit for comparison audits set to " + risk_limit);
+        } catch (final PersistenceException e) {
+          Main.LOGGER.error("unable to set risk limit for comparison audits: " + e);
+        }
+      } else {
+        serverError(the_response, "could not get department of state dashboard"); 
+      }
+    } 
     return my_endpoint_result;
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
@@ -37,7 +37,7 @@ import us.freeandfair.corla.query.PersistentASMStateQueries;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class RiskLimitForComparisonAudits extends AbstractDoSEndpoint {
+public class RiskLimitForComparisonAudits extends AbstractDoSDashboardEndpoint {
   /**
    * The "risk limit" parameter.
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
@@ -11,8 +11,13 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.RLAToolEvent.RLA_TOOL_SKIP_EVENT;
+
 import spark.Request;
 import spark.Response;
+
+import us.freeandfair.corla.asm.ASMEvent;
+import us.freeandfair.corla.asm.AbstractStateMachine;
 
 /**
  * The root endpoint.
@@ -44,5 +49,21 @@ public class Root extends AbstractEndpoint {
   @Override
   public String endpoint(final Request the_request, final Response the_response) {
     return "ColoradoRLA Server, Version 0.0.1 - Please Use a Valid Endpoint!";
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected Class<? extends AbstractStateMachine> asmClass() {
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return RLA_TOOL_SKIP_EVENT;
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
@@ -63,6 +63,14 @@ public class Root extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
+  protected String asmIdentity(final Request the_request) {
+    return null;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   protected ASMEvent endpointEvent() {
     return RLA_TOOL_SKIP_EVENT;
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SelectContestsForAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SelectContestsForAudit.java
@@ -5,11 +5,13 @@
  * @created Aug 9, 2017
  * @copyright 2017 Free & Fair
  * @license GNU General Public License 3.0
- * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @creator Daniel M. Zimmerman <dmz@galois.com>
  * @description A system to assist in conducting statewide risk-limiting audits.
  */
 
 package us.freeandfair.corla.endpoint;
+
+import static us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent.SELECT_CONTESTS_FOR_COMPARISON_AUDIT_EVENT;
 
 import javax.persistence.PersistenceException;
 
@@ -19,6 +21,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.ContestToAudit;
 import us.freeandfair.corla.model.DepartmentOfStateDashboard;
 import us.freeandfair.corla.persistence.Persistence;
@@ -31,7 +34,7 @@ import us.freeandfair.corla.query.DepartmentOfStateDashboardQueries;
  * @version 0.0.1
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class SelectContestsForAudit extends AbstractEndpoint {
+public class SelectContestsForAudit extends AbstractDoSDashboardEndpoint {
   /**
    * {@inheritDoc}
    */
@@ -48,6 +51,14 @@ public class SelectContestsForAudit extends AbstractEndpoint {
     return "/select-contests";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return SELECT_CONTESTS_FOR_COMPARISON_AUDIT_EVENT;
+  }
+  
   /**
    * Attempts to select contests for audit. 
    * 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadRandomSeed.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadRandomSeed.java
@@ -11,12 +11,15 @@
 
 package us.freeandfair.corla.endpoint;
 
+import static us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent.PUBLIC_SEED_EVENT;
+
 import javax.persistence.PersistenceException;
 
 import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.Administrator.AdministratorType;
 import us.freeandfair.corla.model.AuditStage;
 import us.freeandfair.corla.model.DepartmentOfStateDashboard;
@@ -29,8 +32,13 @@ import us.freeandfair.corla.query.DepartmentOfStateDashboardQueries;
  * @author Daniel M Zimmerman
  * @version 0.0.1
  */
+/**
+ * @description <description>
+ * @explanation <explanation>
+ * @bon OPTIONAL_BON_TYPENAME
+ */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class UploadRandomSeed extends AbstractEndpoint {
+public class UploadRandomSeed extends AbstractDoSDashboardEndpoint {
   /**
    * The "random seed" parameter.
    */
@@ -51,6 +59,14 @@ public class UploadRandomSeed extends AbstractEndpoint {
   public String endpointName() {
     return "/random-seed";
   }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return PUBLIC_SEED_EVENT;
+  }
 
   /**
    * Attempts to set the random seed for comparison audits. The random seed
@@ -66,32 +82,25 @@ public class UploadRandomSeed extends AbstractEndpoint {
   public String endpoint(final Request the_request, final Response the_response) {
     ok(the_response, "Random seed set");
     String random_seed = null;
-    
-    if (Authentication.isAuthenticatedAs(the_request, AdministratorType.STATE)) {
-      // see if a valid risk limit was passed in
-      random_seed = the_request.queryParams(RANDOM_SEED);
-
-      if (DepartmentOfStateDashboard.isValidSeed(random_seed)) {
-        final DepartmentOfStateDashboard dosd = DepartmentOfStateDashboardQueries.get();
-        if (dosd != null && dosd.auditStage() == AuditStage.PRE_AUDIT) {
-          dosd.setRandomSeed(random_seed);
-          try {
-            Persistence.saveOrUpdate(dosd);
-            Main.LOGGER.info("random seed set to " + random_seed);
-          } catch (final PersistenceException e) {
-            Main.LOGGER.error("unable to set random seed: " + e);
-          }
-        } else if (dosd == null) {
-          Main.LOGGER.error("could not get department of state dashboard");
-          serverError(the_response, "Could not set random seed");
-        }
+    // see if a valid random seed was passed in
+    random_seed = the_request.queryParams(RANDOM_SEED);
+    if (DepartmentOfStateDashboard.isValidSeed(random_seed)) {
+      final DepartmentOfStateDashboard dosd = 
+          DepartmentOfStateDashboardQueries.get();
+      if (dosd == null) {
+        serverError(the_response, 
+            "Could not get department of state dashboard to set random seed");
       } else {
-        Main.LOGGER.info("attempt to set an invalid random seed");
-        invariantViolation(the_response, "Invalid random seed specified");
+        dosd.setRandomSeed(random_seed);
+        try {
+          Persistence.saveOrUpdate(dosd);
+          Main.LOGGER.info("random seed set to " + random_seed);
+        } catch (final PersistenceException e) {
+          Main.LOGGER.error("unable to set random seed: " + e);
+        }
       }
     } else {
-      Main.LOGGER.info("unauthorized attempt to set the random seed");
-      unauthorized(the_response, "Unauthorized attempt to set the random seed"); 
+      invariantViolation(the_response, "Invalid random seed specified");
     }
     return my_endpoint_result;
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadRandomSeed.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadRandomSeed.java
@@ -20,8 +20,6 @@ import spark.Response;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.asm.ASMEvent;
-import us.freeandfair.corla.model.Administrator.AdministratorType;
-import us.freeandfair.corla.model.AuditStage;
 import us.freeandfair.corla.model.DepartmentOfStateDashboard;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.DepartmentOfStateDashboardQueries;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DepartmentOfStateDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DepartmentOfStateDashboard.java
@@ -141,11 +141,8 @@ public class DepartmentOfStateDashboard extends AbstractEntity implements Serial
    * 
    * @param the_risk_limit The risk limit.
    */
-  //@ requires auditStage() == AuditStage.AUTHENTICATED;
-  //@ ensures auditStage() == AuditStage.RISK_LIMITS_SET;
   public void setRiskLimitForComparisonAudits(final BigDecimal the_risk_limit) {
     my_risk_limit_for_comparison_audits = the_risk_limit;
-    // my_audit_stage = AuditStage.RISK_LIMITS_SET;
   }
   
   /**

--- a/specs/pvs/corla.pvs
+++ b/specs/pvs/corla.pvs
@@ -3039,7 +3039,7 @@ BEGIN
   rla_tool_endpoints: VAR server_endpoints
   undefined_callback: [dashboard -> dashboard]
 %%% Each RLA Tool system endpoint is specified below.
-  root_endpoint: server_endpoint =
+  root_endpoint: server_endpoint = % DONE
     (# endpoint_type := GET,
        callback := undefined_callback,
        uri := "/",
@@ -3051,7 +3051,7 @@ BEGIN
        audit_event := n_e
      #)
 %%% \subsection{Department of State Dashboard Endpoints}
-  auth_state_admin: server_endpoint =
+  auth_state_admin: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/auth-state-admin",
@@ -3063,7 +3063,7 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  risk_limit: server_endpoint =
+  risk_limit: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/risk-limit-comp-audits",
@@ -3076,7 +3076,7 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  select_contests: server_endpoint =
+  select_contests: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/select-contests",
@@ -3089,7 +3089,7 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  publish_data_to_audit: server_endpoint =
+  publish_data_to_audit: server_endpoint = % NOT STARTED
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/publish-data-to-audit",
@@ -3102,11 +3102,11 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  publish_seed: server_endpoint =
+  publish_seed: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
-       uri := "/random-seed", % placeholder
-       implementation_class := "UploadSeed", % placeholder
+       uri := "/random-seed",
+       implementation_class := "UploadRandomSeed",
        in_stream := random_seed_params,
        out_stream := add((BAD_REQUEST_400, nothing),
                      add((UNAUTHORIZED_401, nothing),
@@ -3115,11 +3115,11 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  publish_ballots: server_endpoint =
+  publish_ballots: server_endpoint = % NOT STARTED
     (# endpoint_type := GET,
        callback := undefined_callback,
        uri := "/ballots-to-audit", % placeholder
-       implementation_class := "UploadSeed", % placeholder
+       implementation_class := "PublishBallotsToAudit", % placeholder
        in_stream := ballots_to_audit_params,
        out_stream := add((BAD_REQUEST_400, nothing),
                      add((UNAUTHORIZED_401, nothing),
@@ -3128,7 +3128,7 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  full_hand_count: server_endpoint =
+  full_hand_count: server_endpoint = % NOT STARTED
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/hand-count", % placeholder
@@ -3141,11 +3141,11 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  publish_report: server_endpoint =
+  publish_report: server_endpoint = % NOT STARTED
     (# endpoint_type := GET,
        callback := undefined_callback,
        uri := "/publish-report", % placeholder
-       implementation_class := "PublishAuditReport",
+       implementation_class := "PublishAuditReport", % placeholder
        in_stream := empty_request,
        out_stream := add((BAD_REQUEST_400, nothing),
                      add((UNAUTHORIZED_401, nothing),
@@ -3154,11 +3154,11 @@ BEGIN
        county_event := n_e,
        audit_event := n_e
      #)
-  refresh_department_of_state_dashboard: server_endpoint =
+  refresh_department_of_state_dashboard: server_endpoint = % DONE
     (# endpoint_type := GET,
        callback := undefined_callback,
-       uri := "/dos-dashboard", % placeholder
-       implementation_class := "DepartmentOfStateDashboard",
+       uri := "/dos-dashboard",
+       implementation_class := "DoSDashboardRefresh",
        in_stream := empty_request,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, nothing))),
@@ -3167,7 +3167,7 @@ BEGIN
        audit_event := n_e
      #)
 %%% \subsection{County Dashboard Endpoints}
-  auth_county_admin: server_endpoint =
+  auth_county_admin: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/auth-county-admin",
@@ -3179,11 +3179,11 @@ BEGIN
        county_event := aca_e,
        audit_event := n_e
      #)
-  establish_audit_board: server_endpoint =
+  establish_audit_board: server_endpoint = % NOT STARTED
     (# endpoint_type := POST,
        callback := undefined_callback,
-       uri := "/audit-board",
-       implementation_class := "EstablishAuditBoard",
+       uri := "/audit-board", % placeholder
+       implementation_class := "EstablishAuditBoard", % placeholder
        in_stream := audit_board,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, nothing))),
@@ -3191,7 +3191,7 @@ BEGIN
        county_event := eab_e,
        audit_event := n_e
      #)
-  ballot_manifest_upload: server_endpoint =
+  ballot_manifest_upload: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/upload-ballot-manifest",
@@ -3204,7 +3204,7 @@ BEGIN
        county_event := cuvbm_e,
        audit_event := n_e
      #)
-  cvr_export_upload: server_endpoint =
+  cvr_export_upload: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/upload-cvr-export",
@@ -3217,11 +3217,11 @@ BEGIN
        county_event := uvc_e,
        audit_event := n_e
      #)
-  refresh_county_dashboard: server_endpoint =
+  refresh_county_dashboard: server_endpoint = % DONE
     (# endpoint_type := GET,
        callback := undefined_callback,
-       uri := "/county-dashboard", % placeholder
-       implementation_class := "CountyDashboard",
+       uri := "/county-dashboard",
+       implementation_class := "CountyDashboardRefresh",
        in_stream := empty_request,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, refresh_county_dashboard))),
@@ -3230,7 +3230,7 @@ BEGIN
        audit_event := n_e
      #)
 %%% \subsection{Audit Board Dashboard Endpoints}
-  acvr_upload: server_endpoint = % aka report markings event
+  acvr_upload: server_endpoint = % DONE
     (# endpoint_type := POST,
        callback := undefined_callback,
        uri := "/upload-audit-cvr",
@@ -3243,11 +3243,11 @@ BEGIN
        county_event := n_e,
        audit_event := rm_e
      #)
-  ballot_not_found: server_endpoint =
+  ballot_not_found: server_endpoint = % NOT STARTED
     (# endpoint_type := POST,
        callback := undefined_callback,
-       uri := "/ballot-not-found",
-       implementation_class := "BallotNotFound",
+       uri := "/ballot-not-found", % placeholder
+       implementation_class := "BallotNotFound", % placeholder
        in_stream := ballot_not_found_params,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, nothing))),
@@ -3255,11 +3255,11 @@ BEGIN
        county_event := n_e,
        audit_event := rbnf_e
      #)
-  audit_investigation_report: server_endpoint =
+  audit_investigation_report: server_endpoint = % NOT STARTED
     (# endpoint_type := POST,
        callback := undefined_callback,
-       uri := "/audit-investigation-report",
-       implementation_class := "AuditInvestigationReport",
+       uri := "/audit-investigation-report", % placeholder
+       implementation_class := "AuditInvestigationReport", % placeholder
        in_stream := audit_investigation_report,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, nothing))),
@@ -3267,11 +3267,11 @@ BEGIN
        county_event := n_e,
        audit_event := sair_e
      #)
-  intermediate_audit_report: server_endpoint =
+  intermediate_audit_report: server_endpoint = % NOT STARTED
     (# endpoint_type := POST,
        callback := undefined_callback,
-       uri := "/intermediate-audit-report",
-       implementation_class := "IntermediateAuditReport",
+       uri := "/intermediate-audit-report", % placeholder
+       implementation_class := "IntermediateAuditReport", % placeholder
        in_stream := audit_report,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, nothing))),
@@ -3279,11 +3279,11 @@ BEGIN
        county_event := n_e,
        audit_event := siar_e
      #)
-  audit_report: server_endpoint =
+  audit_report: server_endpoint = % NOT STARTED
     (# endpoint_type := POST,
        callback := undefined_callback,
-       uri := "/audit-report",
-       implementation_class := "AuditReport",
+       uri := "/audit-report", % placeholder
+       implementation_class := "AuditReport", % placeholder
        in_stream := audit_report,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, nothing))),
@@ -3291,11 +3291,11 @@ BEGIN
        county_event := n_e,
        audit_event := sar_e
      #)
-  refresh_audit_board_dashboard: server_endpoint =
+  refresh_audit_board_dashboard: server_endpoint = % NOT STARTED
     (# endpoint_type := GET,
        callback := undefined_callback,
        uri := "/audit-board-dashboard", % placeholder
-       implementation_class := "AuditBoardDashboard",
+       implementation_class := "AuditBoardDashboard", % placeholder
        in_stream := empty_request,
        out_stream := add((UNAUTHORIZED_401, nothing),
                          singleton((OK_200, refresh_audit_board_dashboard))),


### PR DESCRIPTION
This branch implements automatic ASM load, ASM state transition legality, transition, and save via `before` and `after` actions.  Look at `AbstractEndpoint` and `AbstractDoSEndpoint` to perform a design review.