### PR TITLE
Fetch actions

### DIFF
--- a/client/src/action/authCountyAdmin.test.ts
+++ b/client/src/action/authCountyAdmin.test.ts
@@ -35,7 +35,7 @@ const URL = /\/auth-county-admin$/;
 test('authCountyAdmin', s => {
     test('sends the right data', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Authenticated', status: 200 });
+        f.fetch(URL, { body: {}, status: 200 });
 
         t.plan(3);
 
@@ -54,7 +54,7 @@ test('authCountyAdmin', s => {
 
     test('when authenticated', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Authenticated', status: 200 });
+        f.fetch(URL, { body: {}, status: 200 });
 
         t.plan(1);
 
@@ -64,7 +64,7 @@ test('authCountyAdmin', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'AUTH_COUNTY_ADMIN_SEND' },
-                { type: 'AUTH_COUNTY_ADMIN_OK' },
+                { type: 'AUTH_COUNTY_ADMIN_OK', data: {} },
             ]);
 
             teardown(f);
@@ -74,7 +74,7 @@ test('authCountyAdmin', s => {
     test('when auth fails', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Authentication failed',
+            body: { error: 'Authentication failed' },
             status: 401,
         });
 

--- a/client/src/action/authCountyAdmin.test.ts
+++ b/client/src/action/authCountyAdmin.test.ts
@@ -64,7 +64,7 @@ test('authCountyAdmin', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'AUTH_COUNTY_ADMIN_SEND' },
-                { type: 'AUTH_COUNTY_ADMIN_RECEIVE' },
+                { type: 'AUTH_COUNTY_ADMIN_OK' },
             ]);
 
             teardown(f);

--- a/client/src/action/authCountyAdmin.ts
+++ b/client/src/action/authCountyAdmin.ts
@@ -13,7 +13,7 @@ const authCountyAdmin = (username: string, password: string) => {
         fetch(url, { method: 'post', body })
             .then(r => {
                 if (r.ok) {
-                    dispatch({ type: 'AUTH_COUNTY_ADMIN_RECEIVE' });
+                    dispatch({ type: 'AUTH_COUNTY_ADMIN_OK' });
                 } else {
                     dispatch({ type: 'AUTH_COUNTY_ADMIN_FAIL' });
                 }

--- a/client/src/action/authCountyAdmin.ts
+++ b/client/src/action/authCountyAdmin.ts
@@ -2,27 +2,19 @@ import { Dispatch } from 'redux';
 
 import { apiHost } from '../config';
 
-
-const authCountyAdmin = (username: string, password: string) => {
-    return (dispatch: Dispatch<any>) => {
-        dispatch({ type: 'AUTH_COUNTY_ADMIN_SEND' });
-
-        const url = `http://${apiHost}/auth-county-admin`;
-        const body = { username, password };
-
-        fetch(url, { method: 'post', body })
-            .then(r => {
-                if (r.ok) {
-                    dispatch({ type: 'AUTH_COUNTY_ADMIN_OK' });
-                } else {
-                    dispatch({ type: 'AUTH_COUNTY_ADMIN_FAIL' });
-                }
-            })
-            .catch(() => {
-                dispatch({ type: 'AUTH_COUNTY_ADMIN_NETWORK_FAIL' });
-            });
-    };
-};
+import createSubmitAction from './createSubmitAction';
 
 
-export default authCountyAdmin;
+const url = `http://${apiHost}/auth-county-admin`;
+
+const authCountyAdmin = createSubmitAction({
+    failType: 'AUTH_COUNTY_ADMIN_FAIL',
+    networkFailType: 'AUTH_COUNTY_ADMIN_NETWORK_FAIL',
+    okType: 'AUTH_COUNTY_ADMIN_OK',
+    sendType: 'AUTH_COUNTY_ADMIN_SEND',
+    url,
+});
+
+
+export default (username: string, password: string) =>
+    authCountyAdmin({ username, password });

--- a/client/src/action/authStateAdmin.test.ts
+++ b/client/src/action/authStateAdmin.test.ts
@@ -64,7 +64,7 @@ test('authStateAdmin', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'AUTH_STATE_ADMIN_SEND' },
-                { type: 'AUTH_STATE_ADMIN_RECEIVE' },
+                { type: 'AUTH_STATE_ADMIN_OK' },
             ]);
 
             teardown(f);

--- a/client/src/action/authStateAdmin.test.ts
+++ b/client/src/action/authStateAdmin.test.ts
@@ -35,7 +35,7 @@ const URL = /\/auth-state-admin$/;
 test('authStateAdmin', s => {
     test('sends the right data', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Authenticated', status: 200 });
+        f.fetch(URL, { body: {}, status: 200 });
 
         t.plan(3);
 
@@ -54,7 +54,7 @@ test('authStateAdmin', s => {
 
     test('when authenticated', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Authenticated', status: 200 });
+        f.fetch(URL, { body: {}, status: 200 });
 
         t.plan(1);
 
@@ -64,7 +64,7 @@ test('authStateAdmin', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'AUTH_STATE_ADMIN_SEND' },
-                { type: 'AUTH_STATE_ADMIN_OK' },
+                { type: 'AUTH_STATE_ADMIN_OK', data: {} },
             ]);
 
             teardown(f);
@@ -74,7 +74,7 @@ test('authStateAdmin', s => {
     test('when auth fails', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Authentication failed',
+            body: { error: 'Authentication failed' },
             status: 401,
         });
 

--- a/client/src/action/authStateAdmin.ts
+++ b/client/src/action/authStateAdmin.ts
@@ -13,7 +13,7 @@ const authStateAdmin = (username: string, password: string) => {
         fetch(url, { method: 'post', body })
             .then(r => {
                 if (r.ok) {
-                    dispatch({ type: 'AUTH_STATE_ADMIN_RECEIVE' });
+                    dispatch({ type: 'AUTH_STATE_ADMIN_OK' });
                 } else {
                     dispatch({ type: 'AUTH_STATE_ADMIN_FAIL' });
                 }

--- a/client/src/action/authStateAdmin.ts
+++ b/client/src/action/authStateAdmin.ts
@@ -2,27 +2,19 @@ import { Dispatch } from 'redux';
 
 import { apiHost } from '../config';
 
-
-const authStateAdmin = (username: string, password: string) => {
-    return (dispatch: Dispatch<any>) => {
-        dispatch({ type: 'AUTH_STATE_ADMIN_SEND' });
-
-        const url = `http://${apiHost}/auth-state-admin`;
-        const body = { username, password };
-
-        fetch(url, { method: 'post', body })
-            .then(r => {
-                if (r.ok) {
-                    dispatch({ type: 'AUTH_STATE_ADMIN_OK' });
-                } else {
-                    dispatch({ type: 'AUTH_STATE_ADMIN_FAIL' });
-                }
-            })
-            .catch(() => {
-                dispatch({ type: 'AUTH_STATE_ADMIN_NETWORK_FAIL' });
-            });
-    };
-};
+import createSubmitAction from './createSubmitAction';
 
 
-export default authStateAdmin;
+const url = `http://${apiHost}/auth-state-admin`;
+
+const authStateAdmin = createSubmitAction({
+    failType: 'AUTH_STATE_ADMIN_FAIL',
+    networkFailType: 'AUTH_STATE_ADMIN_NETWORK_FAIL',
+    okType: 'AUTH_STATE_ADMIN_OK',
+    sendType: 'AUTH_STATE_ADMIN_SEND',
+    url,
+});
+
+
+export default (username: string, password: string) =>
+    authStateAdmin({ username, password });

--- a/client/src/action/createFetchAction.test.ts
+++ b/client/src/action/createFetchAction.test.ts
@@ -1,0 +1,140 @@
+import * as sinon from 'sinon';
+import * as test from 'tape';
+
+import * as fetch from 'fetch-mock';
+import configureStore from 'redux-mock-store';
+import thunkMiddleware from 'redux-thunk';
+
+import createFetchAction from './createFetchAction';
+
+
+const setup = () => {
+    const data = { the: 'example data' };
+
+    const store = configureStore([thunkMiddleware])({});
+
+    return {
+        data,
+        failType: 'EXAMPLE_FAIL',
+        fetch: (m: any, r: any) =>
+            fetch.mock(m, r).catch(500),
+        networkFailType: 'EXAMPLE_NETWORK_FAIL',
+        okType: 'EXAMPLE_OK',
+        sendType: 'EXAMPLE_SEND',
+        store,
+    };
+};
+
+const teardown = (f: any) => {
+    fetch.restore();
+    f.store.clearActions();
+};
+
+
+const URL = 'http://localhost:4000/example';
+
+
+test('createFetchAction', s => {
+    test('fetches the data', t => {
+        const f = setup();
+        f.fetch(URL, { body: f.data, status: 200 });
+
+        t.plan(2);
+
+        const a = createFetchAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })();
+        a(sinon.stub());
+
+        t.equal(fetch.calls().matched.length, 1, 'fetched to the URL');
+
+        const args: any = fetch.lastCall()[1];
+        t.equal(args, undefined);
+
+        teardown(f);
+    });
+
+    test('when the response is ok', t => {
+        const f = setup();
+        f.fetch(URL, { body: f.data, status: 200 });
+
+        t.plan(1);
+
+        const a = createFetchAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })();
+        f.store.dispatch(a);
+
+        fetch.flush().then(() => {
+            t.deepEqual(f.store.getActions(), [
+                { type: f.sendType },
+                { type: f.okType, data: f.data },
+            ]);
+
+            teardown(f);
+        });
+    });
+
+    test('when there is a server error', t => {
+        const f = setup();
+        f.fetch(URL, {
+            body: 'Server error',
+            status: 500,
+        });
+
+        t.plan(1);
+
+        const a = createFetchAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })();
+        f.store.dispatch(a);
+
+        fetch.flush().then(() => {
+            t.deepEqual(f.store.getActions(), [
+                { type: f.sendType },
+                { type: f.failType },
+            ]);
+
+            teardown(f);
+        });
+    });
+
+    test('when network failure', t => {
+        const f = setup();
+        f.fetch(URL, { throws: 'Network error' });
+
+        t.plan(1);
+
+        const a = createFetchAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })();
+        f.store.dispatch(a);
+
+        fetch.flush().then(() => {
+            t.deepEqual(f.store.getActions(), [
+                { type: f.sendType },
+                { type: f.networkFailType },
+            ]);
+
+            teardown(f);
+        });
+    });
+
+    s.end();
+});

--- a/client/src/action/createFetchAction.ts
+++ b/client/src/action/createFetchAction.ts
@@ -1,0 +1,34 @@
+import { Dispatch } from 'redux';
+
+import { apiHost } from '../config';
+
+
+const createFetchAction = ({
+    failType,
+    networkFailType,
+    okType,
+    sendType,
+    url,
+}: any) => () => {
+    return (dispatch: Dispatch<any>) => {
+        dispatch({ type: sendType });
+
+        fetch(url)
+            .then(r => {
+                if (!r.ok) {
+                    dispatch({ type: failType });
+                    return;
+                }
+
+                r.json().then((data: any) => {
+                    dispatch({ type: okType, data });
+                });
+            })
+            .catch(() => {
+                dispatch({ type: networkFailType });
+            });
+    };
+};
+
+
+export default createFetchAction;

--- a/client/src/action/createSubmitAction.test.ts
+++ b/client/src/action/createSubmitAction.test.ts
@@ -1,0 +1,171 @@
+import * as sinon from 'sinon';
+import * as test from 'tape';
+
+import * as fetch from 'fetch-mock';
+import configureStore from 'redux-mock-store';
+import thunkMiddleware from 'redux-thunk';
+
+import createSubmitAction from './createSubmitAction';
+
+
+const setup = () => {
+    const data = { the: 'reply' };
+
+    const store = configureStore([thunkMiddleware])({});
+
+    return {
+        body: { the: 'submitted data' },
+        data,
+        failType: 'EXAMPLE_FAIL',
+        fetch: (m: any, r: any) =>
+            fetch.mock(m, r).catch(500),
+        networkFailType: 'EXAMPLE_NETWORK_FAIL',
+        okType: 'EXAMPLE_OK',
+        sendType: 'EXAMPLE_SEND',
+        store,
+    };
+};
+
+const teardown = (f: any) => {
+    fetch.restore();
+    f.store.clearActions();
+};
+
+
+const URL = 'http://localhost:4000/example';
+
+
+test('createSubmitAction', s => {
+    test('submits the data', t => {
+        const f = setup();
+        f.fetch(URL, { body: f.data, status: 200 });
+
+        t.plan(3);
+
+        const a = createSubmitAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })(f.body);
+        a(sinon.stub());
+
+        t.equal(fetch.calls().matched.length, 1, 'submitted to the URL');
+
+        const args: any = fetch.lastCall()[1];
+
+        t.equal(args.method, 'post', 'with the right HTTP method');
+        t.deepEqual(args.body, f.body, 'with the right HTTP body');
+
+        teardown(f);
+    });
+
+    test('when the response is ok', t => {
+        const f = setup();
+        f.fetch(URL, { body: f.data, status: 200 });
+
+        t.plan(1);
+
+        const a = createSubmitAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })(f.body);
+        f.store.dispatch(a);
+
+        fetch.flush().then(() => {
+            t.deepEqual(f.store.getActions(), [
+                { type: f.sendType },
+                { type: f.okType, data: f.data },
+            ]);
+
+            teardown(f);
+        });
+    });
+
+    test('when the request is bad', t => {
+        const f = setup();
+        f.fetch(URL, {
+            body: 'Bad request',
+            status: 400,
+        });
+
+        t.plan(1);
+
+        const a = createSubmitAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })(f.body);
+        f.store.dispatch(a);
+
+        fetch.flush().then(() => {
+            t.deepEqual(f.store.getActions(), [
+                { type: f.sendType },
+                { type: f.failType },
+            ]);
+
+            teardown(f);
+        });
+    });
+
+    test('when there is a server error', t => {
+        const f = setup();
+        f.fetch(URL, {
+            body: 'Server error',
+            status: 500,
+        });
+
+        t.plan(1);
+
+        const a = createSubmitAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })(f.body);
+        f.store.dispatch(a);
+
+        fetch.flush().then(() => {
+            t.deepEqual(f.store.getActions(), [
+                { type: f.sendType },
+                { type: f.failType },
+            ]);
+
+            teardown(f);
+        });
+    });
+
+    test('when network failure', t => {
+        const f = setup();
+        f.fetch(URL, { throws: 'Network error' });
+
+        t.plan(1);
+
+        const a = createSubmitAction({
+            failType: f.failType,
+            networkFailType: f.networkFailType,
+            okType: f.okType,
+            sendType: f.sendType,
+            url: URL,
+        })(f.body);
+        f.store.dispatch(a);
+
+        fetch.flush().then(() => {
+            t.deepEqual(f.store.getActions(), [
+                { type: f.sendType },
+                { type: f.networkFailType },
+            ]);
+
+            teardown(f);
+        });
+    });
+
+    s.end();
+});

--- a/client/src/action/createSubmitAction.ts
+++ b/client/src/action/createSubmitAction.ts
@@ -1,0 +1,34 @@
+import { Dispatch } from 'redux';
+
+import { apiHost } from '../config';
+
+
+const createSubmitAction = ({
+    failType,
+    networkFailType,
+    okType,
+    sendType,
+    url,
+}: any) => (body: any) => {
+    return (dispatch: Dispatch<any>) => {
+        dispatch({ type: sendType });
+
+        fetch(url, { method: 'post', body })
+            .then(r => {
+                if (!r.ok) {
+                    dispatch({ type: failType });
+                    return;
+                }
+
+                r.json().then((data: any) => {
+                    dispatch({ type: okType, data });
+                });
+            })
+            .catch(() => {
+                dispatch({ type: networkFailType });
+            });
+    };
+};
+
+
+export default createSubmitAction;

--- a/client/src/action/dosDashboardRefresh.test.ts
+++ b/client/src/action/dosDashboardRefresh.test.ts
@@ -80,7 +80,7 @@ test('dosDashboardRefresh', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'DOS_DASHBOARD_REFRESH_SEND' },
-                { type: 'DOS_DASHBOARD_REFRESH_RECEIVE', data: f.data },
+                { type: 'DOS_DASHBOARD_REFRESH_OK', data: f.data },
             ]);
 
             teardown(f);

--- a/client/src/action/dosDashboardRefresh.ts
+++ b/client/src/action/dosDashboardRefresh.ts
@@ -2,29 +2,18 @@ import { Dispatch } from 'redux';
 
 import { apiHost } from '../config';
 
+import createFetchAction from './createFetchAction';
 
-const dosDashboardRefresh = () => {
-    return (dispatch: Dispatch<any>) => {
-        dispatch({ type: 'DOS_DASHBOARD_REFRESH_SEND' });
 
-        const url = `http://${apiHost}/dos-dashboard`;
+const url = `http://${apiHost}/dos-dashboard`;
 
-        fetch(url)
-            .then(r => {
-                if (!r.ok) {
-                    dispatch({ type: 'DOS_DASHBOARD_REFRESH_FAIL' });
-                    return;
-                }
-
-                r.json().then((data: any) => {
-                    dispatch({ type: 'DOS_DASHBOARD_REFRESH_RECEIVE', data });
-                });
-            })
-            .catch(() => {
-                dispatch({ type: 'DOS_DASHBOARD_REFRESH_NETWORK_FAIL' });
-            });
-    };
-};
+const dosDashboardRefresh = createFetchAction({
+    failType: 'DOS_DASHBOARD_REFRESH_FAIL',
+    networkFailType: 'DOS_DASHBOARD_REFRESH_NETWORK_FAIL',
+    okType: 'DOS_DASHBOARD_REFRESH_RECEIVE',
+    sendType: 'DOS_DASHBOARD_REFRESH_SEND',
+    url,
+});
 
 
 export default dosDashboardRefresh;

--- a/client/src/action/dosDashboardRefresh.ts
+++ b/client/src/action/dosDashboardRefresh.ts
@@ -10,7 +10,7 @@ const url = `http://${apiHost}/dos-dashboard`;
 const dosDashboardRefresh = createFetchAction({
     failType: 'DOS_DASHBOARD_REFRESH_FAIL',
     networkFailType: 'DOS_DASHBOARD_REFRESH_NETWORK_FAIL',
-    okType: 'DOS_DASHBOARD_REFRESH_RECEIVE',
+    okType: 'DOS_DASHBOARD_REFRESH_OK',
     sendType: 'DOS_DASHBOARD_REFRESH_SEND',
     url,
 });

--- a/client/src/action/selectContestsForAudit.test.ts
+++ b/client/src/action/selectContestsForAudit.test.ts
@@ -62,7 +62,7 @@ test('selectContestsForAudit', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'SELECT_CONTESTS_FOR_AUDIT_SEND' },
-                { type: 'SELECT_CONTESTS_FOR_AUDIT_RECEIVE' },
+                { type: 'SELECT_CONTESTS_FOR_AUDIT_OK' },
             ]);
 
             teardown(f);

--- a/client/src/action/selectContestsForAudit.test.ts
+++ b/client/src/action/selectContestsForAudit.test.ts
@@ -33,7 +33,7 @@ const URL = /\/select-contests$/;
 test('selectContestsForAudit', s => {
     test('sends the right data', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Contests selected', status: 200 });
+        f.fetch(URL, { body: { result: 'Contests selected' }, status: 200 });
 
         t.plan(3);
 
@@ -52,7 +52,8 @@ test('selectContestsForAudit', s => {
 
     test('when the contests are selected', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Contests selected', status: 200 });
+        const body = { result: 'Contests selected' };
+        f.fetch(URL, { body, status: 200 });
 
         t.plan(1);
 
@@ -62,7 +63,7 @@ test('selectContestsForAudit', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'SELECT_CONTESTS_FOR_AUDIT_SEND' },
-                { type: 'SELECT_CONTESTS_FOR_AUDIT_OK' },
+                { type: 'SELECT_CONTESTS_FOR_AUDIT_OK', data: body },
             ]);
 
             teardown(f);
@@ -72,7 +73,7 @@ test('selectContestsForAudit', s => {
     test('when the contests are malformed', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Invalid contest selection data',
+            body: { result: 'Invalid contest selection data' },
             status: 422,
         });
 
@@ -94,7 +95,7 @@ test('selectContestsForAudit', s => {
     test('when there is a server error', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Could not select contests',
+            body: { result: 'Could not select contests' },
             status: 500,
         });
 

--- a/client/src/action/selectContestsForAudit.ts
+++ b/client/src/action/selectContestsForAudit.ts
@@ -12,7 +12,7 @@ const selectContestsForAudit = (data: any[]) => {
         fetch(url, { method: 'post', body: data })
             .then(r => {
                 if (r.ok) {
-                    dispatch({ type: 'SELECT_CONTESTS_FOR_AUDIT_RECEIVE' });
+                    dispatch({ type: 'SELECT_CONTESTS_FOR_AUDIT_OK' });
                 } else {
                     dispatch({ type: 'SELECT_CONTESTS_FOR_AUDIT_FAIL' });
                 }

--- a/client/src/action/selectContestsForAudit.ts
+++ b/client/src/action/selectContestsForAudit.ts
@@ -2,26 +2,18 @@ import { Dispatch } from 'redux';
 
 import { apiHost } from '../config';
 
+import createSubmitAction from './createSubmitAction';
 
-const selectContestsForAudit = (data: any[]) => {
-    return (dispatch: Dispatch<any>) => {
-        dispatch({ type: 'SELECT_CONTESTS_FOR_AUDIT_SEND' });
 
-        const url = `http://${apiHost}/select-contests`;
+const url = `http://${apiHost}/select-contests`;
 
-        fetch(url, { method: 'post', body: data })
-            .then(r => {
-                if (r.ok) {
-                    dispatch({ type: 'SELECT_CONTESTS_FOR_AUDIT_OK' });
-                } else {
-                    dispatch({ type: 'SELECT_CONTESTS_FOR_AUDIT_FAIL' });
-                }
-            })
-            .catch(() => {
-                dispatch({ type: 'SELECT_CONTESTS_FOR_AUDIT_NETWORK_FAIL' });
-            });
-    };
-};
+const selectContestsForAudit = createSubmitAction({
+    failType: 'SELECT_CONTESTS_FOR_AUDIT_FAIL',
+    networkFailType: 'SELECT_CONTESTS_FOR_AUDIT_NETWORK_FAIL',
+    okType: 'SELECT_CONTESTS_FOR_AUDIT_OK',
+    sendType: 'SELECT_CONTESTS_FOR_AUDIT_SEND',
+    url,
+});
 
 
 export default selectContestsForAudit;

--- a/client/src/action/setRiskLimit.test.ts
+++ b/client/src/action/setRiskLimit.test.ts
@@ -62,7 +62,7 @@ test('setRiskLimit', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'SET_RISK_LIMIT_SEND' },
-                { type: 'SET_RISK_LIMIT_RECEIVE' },
+                { type: 'SET_RISK_LIMIT_OK' },
             ]);
 
             teardown(f);

--- a/client/src/action/setRiskLimit.test.ts
+++ b/client/src/action/setRiskLimit.test.ts
@@ -33,7 +33,8 @@ const URL = /\/risk-limit-comp-audits$/;
 test('setRiskLimit', s => {
     test('sends the right data', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Risk limit set', status: 200 });
+        const body = { result: 'Risk limit set' };
+        f.fetch(URL, { body, status: 200 });
 
         t.plan(3);
 
@@ -52,7 +53,8 @@ test('setRiskLimit', s => {
 
     test('when the risk limit is set', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Risk limit set', status: 200 });
+        const body = { result: 'Risk limit set' };
+        f.fetch(URL, { body, status: 200 });
 
         t.plan(1);
 
@@ -62,7 +64,7 @@ test('setRiskLimit', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'SET_RISK_LIMIT_SEND' },
-                { type: 'SET_RISK_LIMIT_OK' },
+                { type: 'SET_RISK_LIMIT_OK', data: body },
             ]);
 
             teardown(f);
@@ -72,7 +74,7 @@ test('setRiskLimit', s => {
     test('when the risk limit is invalid', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Invalid risk limit specified',
+            body: { result: 'Invalid risk limit specified' },
             status: 400,
         });
 
@@ -94,7 +96,7 @@ test('setRiskLimit', s => {
     test('when there is a server error', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Could not set a risk limit',
+            body: { result: 'Could not set a risk limit' },
             status: 500,
         });
 

--- a/client/src/action/setRiskLimit.ts
+++ b/client/src/action/setRiskLimit.ts
@@ -2,27 +2,18 @@ import { Dispatch } from 'redux';
 
 import { apiHost } from '../config';
 
-
-const setRiskLimit = (riskLimit: number) => {
-    return (dispatch: Dispatch<any>) => {
-        dispatch({ type: 'SET_RISK_LIMIT_SEND' });
-
-        const url = `http://${apiHost}/risk-limit-comp-audits`;
-        const body = { riskLimit };
-
-        fetch(url, { method: 'post', body })
-            .then(r => {
-                if (r.ok) {
-                    dispatch({ type: 'SET_RISK_LIMIT_OK' });
-                } else {
-                    dispatch({ type: 'SET_RISK_LIMIT_FAIL' });
-                }
-            })
-            .catch(() => {
-                dispatch({ type: 'SET_RISK_LIMIT_NETWORK_FAIL' });
-            });
-    };
-};
+import createSubmitAction from './createSubmitAction';
 
 
-export default setRiskLimit;
+const url = `http://${apiHost}/risk-limit-comp-audits`;
+
+const setRiskLimit = createSubmitAction({
+    failType: 'SET_RISK_LIMIT_FAIL',
+    networkFailType: 'SET_RISK_LIMIT_NETWORK_FAIL',
+    okType: 'SET_RISK_LIMIT_OK',
+    sendType: 'SET_RISK_LIMIT_SEND',
+    url,
+});
+
+
+export default (riskLimit: number) => setRiskLimit({ riskLimit });

--- a/client/src/action/setRiskLimit.ts
+++ b/client/src/action/setRiskLimit.ts
@@ -13,7 +13,7 @@ const setRiskLimit = (riskLimit: number) => {
         fetch(url, { method: 'post', body })
             .then(r => {
                 if (r.ok) {
-                    dispatch({ type: 'SET_RISK_LIMIT_RECEIVE' });
+                    dispatch({ type: 'SET_RISK_LIMIT_OK' });
                 } else {
                     dispatch({ type: 'SET_RISK_LIMIT_FAIL' });
                 }

--- a/client/src/action/uploadBallotManifest.test.ts
+++ b/client/src/action/uploadBallotManifest.test.ts
@@ -75,7 +75,7 @@ test('uploadBallotManifest', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'UPLOAD_BALLOT_MANIFEST_SEND' },
-                { type: 'UPLOAD_BALLOT_MANIFEST_RECEIVE' },
+                { type: 'UPLOAD_BALLOT_MANIFEST_OK' },
             ]);
 
             teardown(f);

--- a/client/src/action/uploadBallotManifest.ts
+++ b/client/src/action/uploadBallotManifest.ts
@@ -17,7 +17,7 @@ const uploadBallotManifest = (countyId: string, file: Blob, hash: string) => {
         fetch(url, { method: 'post', body: formData })
             .then(r => {
                 if (r.ok) {
-                    dispatch({ type: 'UPLOAD_BALLOT_MANIFEST_RECEIVE' });
+                    dispatch({ type: 'UPLOAD_BALLOT_MANIFEST_OK' });
                 } else {
                     dispatch({ type: 'UPLOAD_BALLOT_MANIFEST_FAIL' });
                 }

--- a/client/src/action/uploadCvrExport.test.ts
+++ b/client/src/action/uploadCvrExport.test.ts
@@ -75,7 +75,7 @@ test('uploadCvrExport', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'UPLOAD_CVR_EXPORT_SEND' },
-                { type: 'UPLOAD_CVR_EXPORT_RECEIVE' },
+                { type: 'UPLOAD_CVR_EXPORT_OK' },
             ]);
 
             teardown(f);

--- a/client/src/action/uploadCvrExport.ts
+++ b/client/src/action/uploadCvrExport.ts
@@ -17,7 +17,7 @@ const uploadCvrExport = (countyId: string, file: Blob, hash: string) => {
         fetch(url, { method: 'post', body: formData })
             .then(r => {
                 if (r.ok) {
-                    dispatch({ type: 'UPLOAD_CVR_EXPORT_RECEIVE' });
+                    dispatch({ type: 'UPLOAD_CVR_EXPORT_OK' });
                 } else {
                     dispatch({ type: 'UPLOAD_CVR_EXPORT_FAIL' });
                 }

--- a/client/src/action/uploadRandomSeed.test.ts
+++ b/client/src/action/uploadRandomSeed.test.ts
@@ -33,7 +33,8 @@ const URL = /\/upload-random-seed$/;
 test('uploadRandomSeed', s => {
     test('sends the right data', t => {
         const f = setup();
-        f.fetch(URL, { body: 'OK', status: 200 });
+        const body = { result: 'OK' };
+        f.fetch(URL, { body, status: 200 });
 
         t.plan(3);
 
@@ -52,7 +53,8 @@ test('uploadRandomSeed', s => {
 
     test('when upload ok', t => {
         const f = setup();
-        f.fetch(URL, { body: 'Random seed set', status: 200 });
+        const body = { result: 'Random seed set' };
+        f.fetch(URL, { body, status: 200 });
 
         t.plan(1);
 
@@ -62,7 +64,7 @@ test('uploadRandomSeed', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'UPLOAD_RANDOM_SEED_SEND' },
-                { type: 'UPLOAD_RANDOM_SEED_OK' },
+                { type: 'UPLOAD_RANDOM_SEED_OK', data: body },
             ]);
 
             teardown(f);
@@ -72,7 +74,7 @@ test('uploadRandomSeed', s => {
     test('when server error', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Could not set random seed',
+            body: { result: 'Could not set random seed' },
             status: 500,
         });
 
@@ -94,7 +96,7 @@ test('uploadRandomSeed', s => {
     test('when bad request', t => {
         const f = setup();
         f.fetch(URL, {
-            body: 'Invalid random seed specified',
+            body: { result: 'Invalid random seed specified' },
             status: 400,
         });
 

--- a/client/src/action/uploadRandomSeed.test.ts
+++ b/client/src/action/uploadRandomSeed.test.ts
@@ -62,7 +62,7 @@ test('uploadRandomSeed', s => {
         fetch.flush().then(() => {
             t.deepEqual(f.store.getActions(), [
                 { type: 'UPLOAD_RANDOM_SEED_SEND' },
-                { type: 'UPLOAD_RANDOM_SEED_RECEIVE' },
+                { type: 'UPLOAD_RANDOM_SEED_OK' },
             ]);
 
             teardown(f);

--- a/client/src/action/uploadRandomSeed.ts
+++ b/client/src/action/uploadRandomSeed.ts
@@ -13,7 +13,7 @@ const uploadRandomSeed = (seed: string) => {
         fetch(url, { method: 'post', body })
             .then(r => {
                 if (r.ok) {
-                    dispatch({ type: 'UPLOAD_RANDOM_SEED_RECEIVE' });
+                    dispatch({ type: 'UPLOAD_RANDOM_SEED_OK' });
                 } else {
                     dispatch({ type: 'UPLOAD_RANDOM_SEED_FAIL' });
                 }

--- a/client/src/action/uploadRandomSeed.ts
+++ b/client/src/action/uploadRandomSeed.ts
@@ -2,27 +2,18 @@ import { Dispatch } from 'redux';
 
 import { apiHost } from '../config';
 
-
-const uploadRandomSeed = (seed: string) => {
-    return (dispatch: Dispatch<any>) => {
-        dispatch({ type: 'UPLOAD_RANDOM_SEED_SEND' });
-
-        const url = `http://${apiHost}/upload-random-seed`;
-        const body = { seed };
-
-        fetch(url, { method: 'post', body })
-            .then(r => {
-                if (r.ok) {
-                    dispatch({ type: 'UPLOAD_RANDOM_SEED_OK' });
-                } else {
-                    dispatch({ type: 'UPLOAD_RANDOM_SEED_FAIL' });
-                }
-            })
-            .catch(() => {
-                dispatch({ type: 'UPLOAD_RANDOM_SEED_NETWORK_FAIL' });
-            });
-    };
-};
+import createSubmitAction from './createSubmitAction';
 
 
-export default uploadRandomSeed;
+const url = `http://${apiHost}/upload-random-seed`;
+
+const uploadRandomSeed = createSubmitAction({
+    failType: 'UPLOAD_RANDOM_SEED_FAIL',
+    networkFailType: 'UPLOAD_RANDOM_SEED_NETWORK_FAIL',
+    okType: 'UPLOAD_RANDOM_SEED_OK',
+    sendType: 'UPLOAD_RANDOM_SEED_SEND',
+    url,
+});
+
+
+export default (seed: string) => uploadRandomSeed({ seed });

--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -18,15 +18,15 @@ const defaultState = {
 export default function root(state: AppState = defaultState, action: any) {
     switch (action.type) {
 
-    case 'AUTH_COUNTY_ADMIN_RECEIVE': {
+    case 'AUTH_COUNTY_ADMIN_OK': {
         return { ...state, loggedIn: true, dashboard: 'county', county: {} };
     }
 
-    case 'AUTH_STATE_ADMIN_RECEIVE': {
+    case 'AUTH_STATE_ADMIN_OK': {
         return { ...state, loggedIn: true, dashboard: 'sos', sos: {} };
     }
 
-    case 'DOS_DASHBOARD_REFRESH_RECEIVE': {
+    case 'DOS_DASHBOARD_REFRESH_OK': {
         const nextState = { ...state };
 
         const { data } = action;
@@ -40,12 +40,12 @@ export default function root(state: AppState = defaultState, action: any) {
         return state;
     }
 
-    case 'FETCH_INITIAL_STATE_RECEIVE': {
+    case 'FETCH_INITIAL_STATE_OK': {
         // TODO: should be a deep merge.
         return action.data;
     }
 
-    case 'SELECT_CONTESTS_FOR_AUDIT_RECEIVE': {
+    case 'SELECT_CONTESTS_FOR_AUDIT_OK': {
         return state;
     }
 
@@ -68,7 +68,7 @@ export default function root(state: AppState = defaultState, action: any) {
         return nextState;
     }
 
-    case 'SET_RISK_LIMIT_RECEIVE': {
+    case 'SET_RISK_LIMIT_OK': {
         return state;
     }
 


### PR DESCRIPTION
Closes #255.

This reduces a bunch of a code duplication by introducing two functions that accept a set of actions and a URL, and return an async action creator. This will dramatically speed up the implementation of the remaining county async actions.

We could also try to do this with the file upload actions, but the payoff now is low, relative to cost. There's only two of those, and we don't need any more, so we'll leave them be for now.