### PR TITLE
Fix for logging and transaction isolation

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -372,11 +372,6 @@ public abstract class AbstractEndpoint implements Endpoint {
   @SuppressWarnings("PMD.ConfusingTernary")
   @Override
   public void before(final Request the_request, final Response the_response) {
-    // If this is the root endpoint, just return.
-    if ("/".equals(endpointName())) {
-      return;
-    }
-
     // Start a transaction, if the database is functioning; otherwise abort
     if (Persistence.hasDB()) {
       Persistence.beginTransaction(); 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportUpload.java
@@ -34,7 +34,6 @@ import org.apache.commons.fileupload.FileItemStream;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
-import org.hibernate.Session;
 
 import spark.Request;
 import spark.Response;
@@ -111,10 +110,7 @@ public class CVRExportUpload extends AbstractCountyDashboardEndpoint {
     UploadedFile result = null;
     
     try (FileInputStream is = new FileInputStream(the_info.my_file)) {
-      // we're already in a transaction
-      final Session session = Persistence.currentSession();
-      final Blob blob = 
-          session.getLobHelper().createBlob(is, the_info.my_file.length());
+      final Blob blob = Persistence.blobFor(is, the_info.my_file.length());
       final HashStatus hash_status;
       if (the_info.my_computed_hash == null) {
         hash_status = HashStatus.NOT_CHECKED;
@@ -128,7 +124,7 @@ public class CVRExportUpload extends AbstractCountyDashboardEndpoint {
                                 FileStatus.IMPORTED_AS_CVR_EXPORT, 
                                 the_info.my_uploaded_hash,
                                 hash_status, blob);
-      Persistence.saveOrUpdate(result);
+      Persistence.save(result);
       Persistence.flush();
     } catch (final PersistenceException | IOException e) {
       badDataType(the_response, "could not persist file of size " + 
@@ -231,10 +227,8 @@ public class CVRExportUpload extends AbstractCountyDashboardEndpoint {
     } else if (the_info.my_uploaded_hash.equals(the_info.my_computed_hash)) {
       Main.LOGGER.info("hash matched for uploaded file");
     } else {
-      // NOTE: the only reason this works right now and results in us storing
-      // the file anyway is that we're committing our transaction in 
-      // attemptFilePersistence(); otherwise, this failure response would
-      // abort the transaction and leave the server state unchanged.
+      // NOTE: this failure response means that we don't save the bad file; 
+      // this will be remedied by the new upload mechanism
       badDataContents(the_response, "hash mismatch");
       the_info.my_ok = false;
       attemptFilePersistence(the_response, the_info, the_county.id());

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
@@ -43,7 +43,7 @@ public class Root extends AbstractEndpoint {
    */
   @Override
   public String endpoint(final Request the_request, final Response the_response) {
-    ok(the_response, "ColoradoRLA Server, Version 0.8.0 - Please Use a Valid Endpoint!");
+    ok(the_response, "ColoradoRLA Server, Version 0.9.1 - Please Use a Valid Endpoint!");
     return my_endpoint_result;
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadFile.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadFile.java
@@ -103,10 +103,7 @@ public class UploadFile extends AbstractEndpoint {
     UploadedFile result = null;
     
     try (FileInputStream is = new FileInputStream(the_info.my_file)) {
-      // we're already in a transaction
-      final Session session = Persistence.currentSession();
-      final Blob blob = 
-          session.getLobHelper().createBlob(is, the_info.my_file.length());
+      final Blob blob = Persistence.blobFor(is, the_info.my_file.length());
       final HashStatus hash_status;
       if (the_info.my_computed_hash == null) {
         hash_status = HashStatus.NOT_CHECKED;
@@ -120,8 +117,8 @@ public class UploadFile extends AbstractEndpoint {
                                 FileStatus.IMPORTED_AS_CVR_EXPORT, 
                                 the_info.my_uploaded_hash,
                                 hash_status, blob);
-      Persistence.saveOrUpdate(result);
-      session.flush();
+      Persistence.save(result);
+      Persistence.flush();
     } catch (final PersistenceException | IOException e) {
       badDataType(the_response, "could not persist file of size " + 
                                 the_info.my_file.length());

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadFile.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadFile.java
@@ -30,7 +30,6 @@ import org.apache.commons.fileupload.FileItemStream;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
-import org.hibernate.Session;
 
 import spark.Request;
 import spark.Response;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -309,14 +309,14 @@ public class CountyDashboardRefreshResponse {
    * 
    * @param the_id The ID.
    * @param the_timestamp The timestamp.
-   * @param the_type The type.
+   * @param the_status The type.
    * @return the hash.
    */
   private static String hashForFile(final Long the_id, 
                                     final Instant the_timestamp, 
-                                    final FileStatus the_type) {
+                                    final FileStatus the_status) {
     String result = null;
-    final UploadedFile file = UploadedFileQueries.matching(the_id, the_timestamp, the_type);
+    final UploadedFile file = UploadedFileQueries.matching(the_id, the_timestamp, the_status);
     if (file != null) {
       result = file.hash();
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -305,11 +305,11 @@ public class CountyDashboardRefreshResponse {
   }
   
   /**
-   * Gets the recorded hash for the specified county ID, file timestamp and type.
+   * Gets the recorded hash for the specified county ID, file timestamp and status.
    * 
    * @param the_id The ID.
    * @param the_timestamp The timestamp.
-   * @param the_status The type.
+   * @param the_status The status.
    * @return the hash.
    */
   private static String hashForFile(final Long the_id, 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/UploadedFile.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/UploadedFile.java
@@ -18,6 +18,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
@@ -42,6 +44,8 @@ public class UploadedFile implements PersistentEntity {
    * The database ID.
    */
   @Id
+  @Column(updatable = false, nullable = false)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
   private Long my_id;
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -59,6 +59,16 @@ public final class Persistence {
       "us/freeandfair/corla/persistence/entity_classes";
   
   /**
+   * The "true" constant.
+   */
+  public static final String TRUE = "true";
+  
+  /**
+   * The "false" constant.
+   */
+  public static final String FALSE = "false";
+  
+  /**
    * The "NO SESSION" constant.
    */
   public static final Session NO_SESSION = null;
@@ -146,7 +156,9 @@ public final class Persistence {
   /**
    * Sets up the session factory from the properties in the properties file.
    */
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.ExcessiveMethodLength",
+                     "checkstyle:magicnumber", "checkstyle:executablestatementcount",
+                     "checkstyle:methodlength"})
   private static synchronized void setupSessionFactory() {
     Main.LOGGER.info("attempting to create Hibernate session factory");
     
@@ -174,7 +186,8 @@ public final class Persistence {
                    system_properties.getProperty("hibernate.c3p0.max_statements", ""));
       settings.put(Environment.C3P0_TIMEOUT, 
                    system_properties.getProperty("hibernate.c3p0.timeout", ""));
-
+      settings.put("hibernate.c3p0.privilegeSpawnedThreads", TRUE);
+      settings.put("hibernate.c3p0.contextClassLoaderSource", "library");
       // automatic schema generation
       settings.put(Environment.HBM2DDL_AUTO, 
                    system_properties.getProperty("hibernate.hbm2ddl.auto", ""));
@@ -193,16 +206,18 @@ public final class Persistence {
       
       // concurrency and isolation
       settings.put(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread");
-      settings.put(Environment.USE_STREAMS_FOR_BINARY, "true");
-      settings.put(Environment.ISOLATION, "SERIALIZABLE");
+      settings.put(Environment.USE_STREAMS_FOR_BINARY, TRUE);
+      settings.put(Environment.AUTOCOMMIT, FALSE);
+      settings.put(Environment.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, TRUE);
+      settings.put(Environment.ISOLATION, "REPEATABLE_READ");
       
       // caching 
       settings.put(Environment.JPA_SHARED_CACHE_MODE, "ENABLE_SELECTIVE");
       settings.put(Environment.CACHE_PROVIDER_CONFIG, "org.hibernate.cache.EhCacheProvider");
       settings.put(Environment.CACHE_REGION_FACTORY, 
                    "org.hibernate.cache.ehcache.EhCacheRegionFactory");
-      settings.put(Environment.USE_SECOND_LEVEL_CACHE, "true");
-      settings.put(Environment.USE_QUERY_CACHE, "false");
+      settings.put(Environment.USE_SECOND_LEVEL_CACHE, TRUE);
+      settings.put(Environment.USE_QUERY_CACHE, FALSE);
       settings.put(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "read-write"); 
       
       // apply settings

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -314,14 +314,12 @@ public final class Persistence {
 
     final Session session = currentSession();
     Transaction transaction = null;
-    if (session != null) {
-      try {
-        transaction = session.getTransaction();
-      } catch (final HibernateException e) {
-        // the session did not have a transaction
-      }
+    try {
+      transaction = session.getTransaction();
+    } catch (final HibernateException e) {
+      // the session did not have a transaction
     }
-    return session != null && transaction != null && transaction.getStatus().canRollback();
+    return transaction != null && transaction.getStatus().canRollback();
   }
   
   /**
@@ -617,7 +615,7 @@ public final class Persistence {
    * @exception PersistenceException if there is a problem flushing the session.
    */
   public static void flush() throws PersistenceException {
-    final Session session = currentSession();
+    final Session session = session_info.get();
     if (session != null) {
       session.flush();
     }
@@ -631,7 +629,7 @@ public final class Persistence {
    * @exception IllegalArgumentException if the specified object is not an entity.
    */
   public static void evict(final PersistentEntity the_entity) {
-    final Session session = currentSession();
+    final Session session = session_info.get();
     if (session != null) {
       session.evict(the_entity);
     }
@@ -647,7 +645,7 @@ public final class Persistence {
    * the session.
    */
   public static void flushAndClear() {
-    final Session session = currentSession();
+    final Session session = session_info.get();
     if (session != null) {
       session.flush();
       session.clear();


### PR DESCRIPTION
Fix for logging/transaction isolation issues seen in the previous logging commit. Essentially: relaxed the database's isolation mode from SERIALIZABLE to REPEATABLE_READ (i.e., snapshot isolation).