### PR TITLE
Don't Try to JSONify Proxy Objects

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
@@ -81,7 +81,7 @@ public class ACVRDownload extends AbstractEndpoint {
                         CastVoteRecordQueries.getMatching(RecordType.PHANTOM_BALLOT));
       matches.forEach((the_cvr) -> {
         try {
-          jw.jsonValue(Main.GSON.toJson(the_cvr));
+          jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(the_cvr)));
           Persistence.evict(the_cvr);
         } catch (final IOException e) {
           throw new UncheckedIOException(e);
@@ -90,10 +90,10 @@ public class ACVRDownload extends AbstractEndpoint {
       jw.endArray();
       jw.flush();
       jw.close();
+      ok(the_response);
     } catch (final UncheckedIOException | IOException | PersistenceException e) {
       serverError(the_response, "Unable to stream response");
     }
-    ok(the_response);
     return my_endpoint_result;
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
@@ -90,7 +90,7 @@ public class ACVRDownloadByCounty extends AbstractEndpoint {
                                                             RecordType.PHANTOM_BALLOT));
         matches.forEach((the_cvr) -> {
           try {
-            jw.jsonValue(Main.GSON.toJson(the_cvr));
+            jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(the_cvr)));
             Persistence.evict(the_cvr);
           } catch (final IOException e) {
             throw new UncheckedIOException(e);
@@ -100,10 +100,10 @@ public class ACVRDownloadByCounty extends AbstractEndpoint {
       jw.endArray();
       jw.flush();
       jw.close();
+      ok(the_response);
     } catch (final UncheckedIOException | IOException | PersistenceException e) {
       serverError(the_response, "Unable to stream response");
     }
-    ok(the_response);
     return my_endpoint_result;
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
@@ -80,7 +80,7 @@ public class CVRDownload extends AbstractEndpoint {
           CastVoteRecordQueries.getMatching(RecordType.UPLOADED);
       matches.forEach((the_cvr) -> {
         try {
-          jw.jsonValue(Main.GSON.toJson(the_cvr));
+          jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(the_cvr)));
           Persistence.evict(the_cvr);
         } catch (final IOException e) {
           throw new UncheckedIOException(e);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
@@ -87,7 +87,7 @@ public class CVRDownloadByCounty extends AbstractEndpoint {
             CastVoteRecordQueries.getMatching(county, RecordType.UPLOADED);
         matches.forEach((the_cvr) -> {
           try {
-            jw.jsonValue(Main.GSON.toJson(the_cvr));
+            jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(the_cvr)));
             Persistence.evict(the_cvr);
           } catch (final IOException e) {
             throw new UncheckedIOException(e);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
@@ -62,7 +62,7 @@ public class CVRDownloadByID extends AbstractEndpoint {
       if (c == null) {
         dataNotFound(the_response, "CVR not found");
       } else {
-        okJSON(the_response, Main.GSON.toJson(c));
+        okJSON(the_response, Main.GSON.toJson(Persistence.unproxy(c)));
       }
     } catch (final NumberFormatException e) {
       invariantViolation(the_response, "Bad CVR ID");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
@@ -18,11 +18,14 @@ import java.io.OutputStreamWriter;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.google.gson.stream.JsonWriter;
+
 import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.model.Contest;
+import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.ContestQueries;
 import us.freeandfair.corla.util.SparkHelper;
 
@@ -76,9 +79,15 @@ public class ContestDownloadByCounty extends AbstractEndpoint {
         try {
           final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
           final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-
-          Main.GSON.toJson(contest_set, bw);
-          bw.flush();
+          final JsonWriter jw = new JsonWriter(bw);
+          jw.beginArray();
+          for (final Contest contest : contest_set) {
+            jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(contest)));
+            Persistence.evict(contest);
+          } 
+          jw.endArray();
+          jw.flush();
+          jw.close();
           ok(the_response);
         } catch (final IOException e) {
           serverError(the_response, "Unable to stream response");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
@@ -62,7 +62,7 @@ public class ContestDownloadByID extends AbstractEndpoint {
       if (c == null) {
         dataNotFound(the_response, "Contest not found");
       } else {
-        okJSON(the_response, Main.GSON.toJson(c));
+        okJSON(the_response, Main.GSON.toJson(Persistence.unproxy(c)));
       }
     } catch (final NumberFormatException e) {
       invariantViolation(the_response, "Bad contest ID");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/County.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/County.java
@@ -63,7 +63,6 @@ public class County implements PersistentEntity, Serializable {
    * The version (for optimistic locking).
    */
   @Version
-  @SuppressWarnings("PMD.UnusedPrivateField")
   private Long my_version;
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -92,7 +92,6 @@ public class CountyDashboard implements PersistentEntity, Serializable {
    * The version (for optimistic locking).
    */
   @Version
-  @SuppressWarnings("PMD.UnusedPrivateField")
   private Long my_version;
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DoSDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DoSDashboard.java
@@ -75,7 +75,6 @@ public class DoSDashboard implements PersistentEntity, Serializable {
    * The version (for optimistic locking).
    */
   @Version
-  @SuppressWarnings("PMD.UnusedPrivateField")
   private Long my_version;
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/UploadedFile.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/UploadedFile.java
@@ -52,7 +52,6 @@ public class UploadedFile implements PersistentEntity {
    * The version (for optimistic locking).
    */
   @Version
-  @SuppressWarnings("PMD.UnusedPrivateField")
   private Long my_version;
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/AbstractEntity.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/AbstractEntity.java
@@ -43,7 +43,6 @@ public abstract class AbstractEntity implements PersistentEntity {
    * The version (for optimistic locking).
    */
   @Version
-  @SuppressWarnings("PMD.UnusedPrivateField")
   private Long my_version;
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -30,6 +30,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
+import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.ObjectNotFoundException;
 import org.hibernate.Session;
@@ -663,6 +664,18 @@ public final class Persistence {
   public static Blob blobFor(final InputStream the_stream, final long the_size) {
     checkForRunningTransaction();
     return currentSession().getLobHelper().createBlob(the_stream, the_size);
+  }
+  
+  /**
+   * Unwraps an object from its proxy object, if any; typically used before 
+   * converting the entity to JSON for wire transmission.
+   * 
+   * @param the_object The object.
+   * @return the unwrapped object; if the object is not a proxy, it is returned
+   * unchanged.
+   */
+  public static Object unproxy(final Object the_object) {
+    return Hibernate.unproxy(the_object);
   }
   
   /**


### PR DESCRIPTION
Closes #395 

Hibernate uses proxy objects. Lots of them. Especially when doing lazy loading. Unfortunately, Gson doesn't like serializing proxy objects, because it doesn't know what they are - which is a cause of some of the `GeneralError`s we've seen in the CDOS server logs. Fortunately, Hibernate 5.2.10 (yes, the very version we're using) added an `unproxy` utility method! And it has the very nice property that if you call it on something that's not a proxy, it's a no-op. So, unless I missed one somewhere, I'm now wrapping every single entity that is directly converted to JSON in an `unproxy` call to avoid possible proxy serialization unpleasantness.