### PR TITLE
Fixed the ballots to audit calculation for DoS dashboard

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
@@ -166,7 +166,7 @@ public class DoSDashboardRefreshResponse {
       to_audit = 
           Math.max(to_audit, 
                    Math.max(0, ccca.ballotsToAudit() - 
-                               ccca.dashboard().ballotsAudited()));
+                               ccca.dashboard().auditedPrefixLength()));
     }
     return to_audit;
   }


### PR DESCRIPTION
I was using the total number of audited ballots instead of the length of the prefix of the random sequence that had been audited. That has been fixed.