### PR TITLE
Audit board sign-in buttons

### DIFF
--- a/client/src/component/county/AuditBoardSignInPage.tsx
+++ b/client/src/component/county/AuditBoardSignInPage.tsx
@@ -13,7 +13,10 @@ function validateElector(elector: any) {
         && elector.party;
 }
 
-function validateForm(auditBoard: any) {
+function validateAuditBoard(auditBoard: any) {
+    if (!auditBoard[0]) { return false; }
+    if (!auditBoard[1]) { return false; }
+
     return validateElector(auditBoard[0])
         && validateElector(auditBoard[1]) ;
 }
@@ -44,6 +47,8 @@ class AuditBoardSignInStage extends React.Component<any, any> {
         const submit = () => {
             establishAuditBoard(this.state.form);
         };
+
+        const boardEstablished = validateAuditBoard(auditBoard);
 
         if (auditBoard.length === 2) {
             return (
@@ -77,14 +82,17 @@ class AuditBoardSignInStage extends React.Component<any, any> {
                     </div>
                     <div>
                     </div>
-                    <button className='pt-button pt-intent-primary' onClick={ submit }>
+                    <button
+                        disabled={ boardEstablished }
+                        className='pt-button pt-intent-primary'
+                        onClick={ submit }>
                         Submit
                     </button>
                 </div>
             );
         }
 
-        const disableButton = !validateForm(this.state.form);
+        const disableButton = !validateAuditBoard(this.state.form);
 
         return (
             <div>

--- a/client/src/component/county/home/CountyHomeContainer.tsx
+++ b/client/src/component/county/home/CountyHomeContainer.tsx
@@ -14,9 +14,10 @@ class CountyHomeContainer extends React.Component<any, any> {
         } = this.props;
 
         const countyInfo = county.id ? counties[county.id] : {};
+        const boardSignIn = () => history.push('/county/sign-in');
         const startAudit = () => history.push('/county/audit');
 
-        const props = { countyInfo, startAudit, ...this.props };
+        const props = { boardSignIn, countyInfo, startAudit, ...this.props };
 
         return <CountyHomePage { ...props } />;
     }

--- a/client/src/component/county/home/CountyHomePage.tsx
+++ b/client/src/component/county/home/CountyHomePage.tsx
@@ -8,7 +8,7 @@ import CountyNav from '../Nav';
 import FileUploadContainer from './FileUploadContainer';
 
 
-const Main = ({ buttonDisabled, name, startAudit }: any) => {
+const Main = ({ boardSignIn, buttonDisabled, name, startAudit }: any) => {
     return (
         <div className='county-main pt-card'>
             <h1>Hello, { name } County!</h1>
@@ -18,9 +18,18 @@ const Main = ({ buttonDisabled, name, startAudit }: any) => {
                 </div>
                 <FileUploadContainer />
                 <button
+                    className='pt-button pt-intent-primary'
+                    onClick={ boardSignIn }>
+                    <span className='pt-icon-standard pt-icon-people' />
+                    <span> </span>
+                    Audit Board Sign-In
+                </button>
+                <button
                     disabled={ buttonDisabled }
                     className='pt-button pt-intent-primary'
                     onClick={ startAudit }>
+                    <span className='pt-icon-standard pt-icon-eye-open' />
+                    <span> </span>
                     Start Audit
                 </button>
             </div>
@@ -117,6 +126,7 @@ const Info = ({ info, contests, county }: any) => (
 
 const CountyHomePage = (props: any) => {
     const {
+        boardSignIn,
         contests,
         county,
         countyInfo,
@@ -142,7 +152,8 @@ const CountyHomePage = (props: any) => {
         <div className='county-root'>
             <CountyNav />
             <div>
-                <Main buttonDisabled={ buttonDisabled }
+                <Main boardSignIn={ boardSignIn }
+                      buttonDisabled={ buttonDisabled }
                       name={ countyInfo.name }
                       startAudit={ startAudit } />
                 <Info info={ countyInfo }


### PR DESCRIPTION
Adds a button to link directly to the audit board sign-in page, and disables that page's "submit" button if the board has already signed in.