### PR TITLE
Fixed Concurrency for Spark Endpoints

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
@@ -94,6 +94,6 @@ public class ACVRDownload extends AbstractEndpoint {
     } catch (final UncheckedIOException | IOException | PersistenceException e) {
       serverError(the_response, "Unable to stream response");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
@@ -104,7 +104,7 @@ public class ACVRDownloadByCounty extends AbstractEndpoint {
     } catch (final UncheckedIOException | IOException | PersistenceException e) {
       serverError(the_response, "Unable to stream response");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
@@ -123,6 +123,6 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
       Main.LOGGER.error("could not save audit CVR");
       serverError(the_response, "Unable to save audit CVR");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -364,7 +364,6 @@ public abstract class AbstractEndpoint implements Endpoint {
     my_status.set(HttpStatus.SERVICE_UNAVAILABLE_503);
     the_response.header("Retry-After", RETRY_AFTER_DELAY);
     my_endpoint_result.set(Main.GSON.toJson(new Result(the_body)));
-    halt(the_response);
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -146,7 +146,8 @@ public abstract class AbstractEndpoint implements Endpoint {
                                  final Response the_response) {
     // get the state of the ASM
     if (DISABLE_ASM || asmClass() == null) {
-      // there is no ASM event for this endpoint
+      // there is no ASM for this endpoint
+      my_asm.set(null);
       return;
     }
     my_asm.set(ASMUtilities.asmFor(asmClass(), asmIdentity(the_request)));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardDashboardASMState.java
@@ -50,8 +50,8 @@ public class AuditBoardDashboardASMState extends AbstractAuditBoardDashboardEndp
     // conveniently have locally already
     
     okJSON(the_response, 
-           Main.GSON.toJson(new ServerASMResponse(my_asm.currentState(), 
-                                                  my_asm.enabledUIEvents())));
-    return my_endpoint_result;
+           Main.GSON.toJson(new ServerASMResponse(my_asm.get().currentState(), 
+                                                  my_asm.get().enabledUIEvents())));
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditInvestigationReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditInvestigationReport.java
@@ -94,6 +94,6 @@ public class AuditInvestigationReport extends AbstractAuditBoardDashboardEndpoin
       serverError(the_response, "Unable to save audit investigation report");
     }
     ok(the_response, "Report submitted");
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditReport.java
@@ -74,7 +74,7 @@ public class AuditReport extends AbstractAuditBoardDashboardEndpoint {
     try {
       if (!DISABLE_ASM) {
         ASMUtilities.step(COUNTY_AUDIT_COMPLETE_EVENT, 
-                          CountyDashboardASM.class, my_asm.identity());
+                          CountyDashboardASM.class, my_asm.get().identity());
         // check to see if all counties are complete
         boolean all_complete = true;
         for (final County c : Persistence.getAll(County.class)) {
@@ -92,6 +92,6 @@ public class AuditReport extends AbstractAuditBoardDashboardEndpoint {
     } catch (final IllegalStateException e) {
       illegalTransition(the_response, e.getMessage());
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
@@ -111,6 +111,6 @@ public class AuthenticateCountyAdministrator extends AbstractEndpoint {
         unauthorized(the_response, "Authentication failed");
       }
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
@@ -112,6 +112,6 @@ public class AuthenticateStateAdministrator extends AbstractEndpoint {
         unauthorized(the_response, "Authentication failed");
       }
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
@@ -79,6 +79,6 @@ public class BallotManifestDownload extends AbstractCountyDashboardEndpoint {
     } catch (final IOException e) {
       serverError(the_response, "Unable to stream response");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
@@ -88,7 +88,7 @@ public class BallotManifestDownloadByCounty extends AbstractCountyDashboardEndpo
     } else {
       dataNotFound(the_response, "Invalid county ID specified");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestUpload.java
@@ -283,7 +283,7 @@ public class BallotManifestUpload extends AbstractCountyDashboardEndpoint {
 
     if (county == null) {
       unauthorized(the_response, "unauthorized administrator for ballot manifest upload");
-      return my_endpoint_result;
+      return my_endpoint_result.get();
     }
     
     handleUpload(the_request, the_response, info);
@@ -309,7 +309,7 @@ public class BallotManifestUpload extends AbstractCountyDashboardEndpoint {
       }
     }
 
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotNotFound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotNotFound.java
@@ -83,13 +83,13 @@ public class BallotNotFound extends AbstractAuditBoardDashboardEndpoint {
     final County county = Authentication.authenticatedCounty(the_request);
     if (county == null) {
       unauthorized(the_response, "not authorized for audit board operations");
-      return my_endpoint_result;
+      return my_endpoint_result.get();
     }
     
     final CountyDashboard cdb = Persistence.getByID(county.id(), CountyDashboard.class);
     if (cdb == null) {
       serverError(the_response, "could not load audit board information");
-      return my_endpoint_result;
+      return my_endpoint_result.get();
     }
     
     // attempt to read the CVR ID from the request
@@ -129,7 +129,7 @@ public class BallotNotFound extends AbstractAuditBoardDashboardEndpoint {
     } catch (final PersistenceException e) {
       this.serverError(the_response, "unable to save audit CVR");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
@@ -93,6 +93,6 @@ public class CVRDownload extends AbstractEndpoint {
     } catch (final UncheckedIOException | IOException | PersistenceException e) {
       serverError(the_response, "Unable to stream response");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
@@ -101,7 +101,7 @@ public class CVRDownloadByCounty extends AbstractEndpoint {
     } catch (final UncheckedIOException | IOException | PersistenceException e) {
       serverError(the_response, "Unable to stream response");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
@@ -68,6 +68,6 @@ public class CVRDownloadByID extends AbstractEndpoint {
       invariantViolation(the_response, "Bad CVR ID");
     }
     
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportUpload.java
@@ -271,7 +271,7 @@ public class CVRExportUpload extends AbstractCountyDashboardEndpoint {
 
     if (county == null) {
       unauthorized(the_response, "unauthorized administrator for CVR export upload");
-      return my_endpoint_result;
+      return my_endpoint_result.get();
     } 
 
     handleUpload(the_request, the_response, info);
@@ -299,7 +299,7 @@ public class CVRExportUpload extends AbstractCountyDashboardEndpoint {
         // ignored - should never happen
       }
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
@@ -86,6 +86,6 @@ public class ContestDownload extends AbstractEndpoint {
     } catch (final IOException e) {
       serverError(the_response, "Unable to stream response");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
@@ -96,7 +96,7 @@ public class ContestDownloadByCounty extends AbstractEndpoint {
     } else {
       dataNotFound(the_response, "Invalid county ID specified");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
@@ -67,6 +67,6 @@ public class ContestDownloadByID extends AbstractEndpoint {
     } catch (final NumberFormatException e) {
       invariantViolation(the_response, "Bad contest ID");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardASMState.java
@@ -50,8 +50,8 @@ public class CountyDashboardASMState extends AbstractCountyDashboardEndpoint {
     // conveniently have locally already
     
     okJSON(the_response, 
-           Main.GSON.toJson(new ServerASMResponse(my_asm.currentState(), 
-                                                  my_asm.enabledUIEvents())));
-    return my_endpoint_result;
+           Main.GSON.toJson(new ServerASMResponse(my_asm.get().currentState(), 
+                                                  my_asm.get().enabledUIEvents())));
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
@@ -64,7 +64,7 @@ public class CountyDashboardRefresh extends AbstractCountyDashboardEndpoint {
     } catch (final PersistenceException e) {
       serverError(the_response, "could not obtain dashboard state");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardASMState.java
@@ -50,8 +50,8 @@ public class DoSDashboardASMState extends AbstractDoSDashboardEndpoint {
     // conveniently have locally already
     
     okJSON(the_response, 
-           Main.GSON.toJson(new ServerASMResponse(my_asm.currentState(), 
-                                                  my_asm.enabledUIEvents())));
-    return my_endpoint_result;
+           Main.GSON.toJson(new ServerASMResponse(my_asm.get().currentState(), 
+                                                  my_asm.get().enabledUIEvents())));
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
@@ -61,7 +61,7 @@ public class DoSDashboardRefresh extends AbstractDoSDashboardEndpoint {
     } catch (final PersistenceException e) {
       serverError(the_response, "could not obtain dashboard state");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/EstablishAuditBoard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/EstablishAuditBoard.java
@@ -123,6 +123,6 @@ public class EstablishAuditBoard extends AbstractCountyDashboardEndpoint {
     } catch (final JsonSyntaxException e) {
       badDataContents(the_response, "Invalid audit board data");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IndicateHandCount.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IndicateHandCount.java
@@ -98,6 +98,6 @@ public class IndicateHandCount extends AbstractDoSDashboardEndpoint {
       Main.LOGGER.error("could not save contest selection");
       serverError(the_response, "Unable to save contest selection");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
@@ -94,6 +94,6 @@ public class IntermediateAuditReport extends AbstractAuditBoardDashboardEndpoint
     }
     ok(the_response, "Report submitted");
     // de-authenticate user?
-    return my_endpoint_result;    
+    return my_endpoint_result.get();    
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishAuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishAuditReport.java
@@ -64,6 +64,6 @@ public class PublishAuditReport extends AbstractDoSDashboardEndpoint {
   public String endpoint(final Request the_request,
                          final Response the_response) {
     ok(the_response, "Publish the audit report for the entire state-wide RLA.");
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishBallotsToAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishBallotsToAudit.java
@@ -111,6 +111,6 @@ public class PublishBallotsToAudit extends AbstractDoSDashboardEndpoint {
       serverError(the_response, "could not publish list of ballots to audit");
     }
     
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishDataToAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishDataToAudit.java
@@ -66,6 +66,6 @@ public class PublishDataToAudit extends AbstractDoSDashboardEndpoint {
                          final Response the_response) {
     ok(the_response, "When defined, the full set of data relevant to permitting the" +
                      "public to audit an RLA will be downloaded here.");
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ReportBallotsToAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ReportBallotsToAudit.java
@@ -54,6 +54,6 @@ public class ReportBallotsToAudit extends AbstractDoSDashboardEndpoint {
                          final Response the_response) {
     ok(the_response, "the report of ballots to audit is not yet implemented, but " + 
                      "the information can be obtained from county dashboard states");
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ResetDatabase.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ResetDatabase.java
@@ -166,6 +166,6 @@ public class ResetDatabase extends AbstractEndpoint {
     
     ok(the_response, "database reset; run vacuumlo on the database to " + 
                      "recover space from large object storage");
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
@@ -99,7 +99,7 @@ public class RiskLimitForComparisonAudits extends AbstractDoSDashboardEndpoint {
     } catch (final JsonSyntaxException e) {
       invariantViolation(the_response, "Invalid risk limit specified");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
@@ -44,6 +44,6 @@ public class Root extends AbstractEndpoint {
   @Override
   public String endpoint(final Request the_request, final Response the_response) {
     ok(the_response, "ColoradoRLA Server, Version 0.9.1 - Please Use a Valid Endpoint!");
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SelectContestsForAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SelectContestsForAudit.java
@@ -89,6 +89,6 @@ public class SelectContestsForAudit extends AbstractDoSDashboardEndpoint {
       Main.LOGGER.error("could not save contest selection");
       serverError(the_response, "Unable to save contest selection");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Unauthenticate.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Unauthenticate.java
@@ -90,6 +90,6 @@ public class Unauthenticate extends AbstractEndpoint {
   public String endpoint(final Request the_request, final Response the_response) {
     Authentication.unauthenticate(the_request);
     ok(the_response, "Unauthenticated");
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadFile.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadFile.java
@@ -193,7 +193,7 @@ public class UploadFile extends AbstractEndpoint {
 
     if (county == null) {
       unauthorized(the_response, "unauthorized administrator for CVR export upload");
-      return my_endpoint_result;
+      return my_endpoint_result.get();
     } 
 
     handleUpload(the_request, the_response, info);
@@ -219,7 +219,7 @@ public class UploadFile extends AbstractEndpoint {
         // ignored - should never happen
       }
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadRandomSeed.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UploadRandomSeed.java
@@ -102,6 +102,6 @@ public class UploadRandomSeed extends AbstractDoSDashboardEndpoint {
     } catch (final JsonSyntaxException e) {
       badDataContents(the_response, "Invalid random seed request");
     }
-    return my_endpoint_result;
+    return my_endpoint_result.get();
   }
 }


### PR DESCRIPTION
Due to a fundamental misunderstanding of how Spark uses endpoints, they were not sufficiently thread-safe. Now they are.

Closes #447  (for real this time)