### PR TITLE
CVRs to Audit List

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -50,6 +50,7 @@ import us.freeandfair.corla.endpoint.CORSFilter;
 import us.freeandfair.corla.endpoint.Endpoint;
 import us.freeandfair.corla.json.FreeAndFairNamingStrategy;
 import us.freeandfair.corla.json.InstantTypeAdapter;
+import us.freeandfair.corla.json.VersionExclusionStrategy;
 import us.freeandfair.corla.model.Administrator;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
@@ -131,6 +132,7 @@ public final class Main {
       new GsonBuilder().
       registerTypeAdapter(Instant.class, new InstantTypeAdapter()).
       setFieldNamingStrategy(new FreeAndFairNamingStrategy()).
+      setExclusionStrategies(new VersionExclusionStrategy()).
       setPrettyPrinting().create();
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/ColoradoBallotManifestParser.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/ColoradoBallotManifestParser.java
@@ -155,8 +155,8 @@ public class ColoradoBallotManifestParser implements BallotManifestParser {
       // one we were passed at construction and the county name string 
       // in the file?
       result = new BallotManifestInfo(my_county_id,
-                                      the_line.get(SCANNER_ID_COLUMN),
-                                      the_line.get(BATCH_NUMBER_COLUMN),
+                                      Integer.parseInt(the_line.get(SCANNER_ID_COLUMN)),
+                                      Integer.parseInt(the_line.get(BATCH_NUMBER_COLUMN)),
                                       Integer.parseInt(the_line.
                                                        get(NUM_BALLOTS_COLUMN)),
                                       the_line.get(BATCH_LOCATION_COLUMN));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -528,7 +528,8 @@ public abstract class AbstractEndpoint implements Endpoint {
     String endpoint_result = my_endpoint_result.get();
     if (status == null) {
       status = HttpStatus.INTERNAL_SERVER_ERROR_500;
-      endpoint_result = "runtime error, no status recorded by endpoint";
+      endpoint_result = 
+          Main.GSON.toJson(new Result("server error, no response from endpoint"));
     }
     the_response.body(endpoint_result);
     the_response.status(status);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -141,7 +141,6 @@ public abstract class AbstractEndpoint implements Endpoint {
    * @param the_request The request.
    * @param the_response The response.
    */
-  @SuppressWarnings("unused")
   protected void loadAndCheckASM(final Request the_request,
                                  final Response the_response) {
     // get the state of the ASM
@@ -167,7 +166,6 @@ public abstract class AbstractEndpoint implements Endpoint {
    * @param the_response The response.
    * @return true if the ASM transitioned successfully
    */
-  @SuppressWarnings("unused")
   protected boolean transitionAndSaveASM(final Response the_response)  {
     if (DISABLE_ASM || my_asm.get() == null || endpointEvent() == null) {
       // there is no ASM event for this endpoint

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestImport.java
@@ -114,11 +114,6 @@ public class BallotManifestImport extends AbstractCountyDashboardEndpoint {
         final int imported = parser.recordCount().getAsInt();
         Main.LOGGER.info(imported + " ballot manifest records parsed from file " + 
                          the_file.id());
-//        final OptionalLong count = BallotManifestInfoQueries.count();
-//        if (count.isPresent()) {
-//          Main.LOGGER.info(count.getAsLong() + 
-//                           " uploaded ballot manifest records in storage");
-//        }
         updateCountyDashboard(the_response, the_file.countyID(), the_file.timestamp());
         the_file.setStatus(FileStatus.IMPORTED_AS_BALLOT_MANIFEST);
         Persistence.saveOrUpdate(the_file);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotNotFound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotNotFound.java
@@ -106,7 +106,7 @@ public class BallotNotFound extends AbstractAuditBoardDashboardEndpoint {
       }
       final CastVoteRecord cvr = Persistence.getByID(sbnf.id(), CastVoteRecord.class);
       if (cvr == null) {
-        badDataContents(the_response, "nonexistent CVR id");
+        badDataContents(the_response, "nonexistent CVR ID");
       }
       final List<CVRAuditInfo> matching = CVRAuditInfoQueries.matching(cdb, cvr);
       if (matching.isEmpty()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -114,11 +114,6 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
       if (parser.parse()) {
         final int imported = parser.recordCount().getAsInt();
         Main.LOGGER.info(imported + " CVRs parsed from file " + the_file.id());
-//        final OptionalLong count = 
-//            CastVoteRecordQueries.countMatching(RecordType.UPLOADED);
-//        if (count.isPresent()) {
-//          Main.LOGGER.info(count.getAsLong() + " uploaded CVRs in storage");
-//        }
         updateCountyDashboard(the_response, the_file.countyID(), the_file.timestamp());
         the_file.setStatus(FileStatus.IMPORTED_AS_CVR_EXPORT);
         Persistence.saveOrUpdate(the_file);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -152,7 +152,10 @@ public class CVRToAuditList extends AbstractEndpoint {
       int start = index;
       int end = start + ballot_count - 1; // end is inclusive
       
-      while (cvr_set.size() < ballot_count && cvr_set.size() < county_ballots) {
+      // if duplicates is set we go until the list has the right number; if not,
+      // we go until we hit the end of our CVR pool
+      while (duplicates && cvr_to_audit_list.size() < ballot_count || 
+             !duplicates && cvr_set.size() < ballot_count && cvr_set.size() < county_ballots) {
         final List<CastVoteRecord> new_cvrs = 
             ComparisonAuditController.computeBallotOrder(cdb, start, end);
         for (int i = 0; i < new_cvrs.size(); i++) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -133,7 +133,8 @@ public class CVRToAuditList extends AbstractEndpoint {
             final String location = BallotManifestInfoQueries.locationFor(cvr);
             cvr_to_audit_list.add(new CVRToAuditResponse(start + i, cvr.scannerID(), 
                                                          cvr.batchID(), cvr.recordID(), 
-                                                         cvr.imprintedID(),
+                                                         cvr.imprintedID(), 
+                                                         cvr.cvrNumber(), cvr.id(),
                                                          cvr.ballotType(), location));
             cvr_set.add(cvr);
           }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -42,7 +42,7 @@ import us.freeandfair.corla.query.CastVoteRecordQueries;
  * @author Daniel M. Zimmerman
  * @version 0.0.1
  */
-@SuppressWarnings("PMD.AtLeastOneConstructor")
+@SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.CyclomaticComplexity"})
 public class CVRToAuditList extends AbstractEndpoint {
   /**
    * The "start" parameter.
@@ -157,7 +157,7 @@ public class CVRToAuditList extends AbstractEndpoint {
             ComparisonAuditController.computeBallotOrder(cdb, start, end);
         for (int i = 0; i < new_cvrs.size(); i++) {
           final CastVoteRecord cvr = new_cvrs.get(i);
-          if ((duplicates || !cvr_set.contains(cvr)) && notAudited(cdb, cvr)) {
+          if ((duplicates || !cvr_set.contains(cvr)) && notAudited(cvr)) {
             // get the CVR location
             final String location = BallotManifestInfoQueries.locationFor(cvr);
             cvr_to_audit_list.add(new CVRToAuditResponse(start + i, cvr.scannerID(), 
@@ -165,8 +165,8 @@ public class CVRToAuditList extends AbstractEndpoint {
                                                          cvr.imprintedID(), 
                                                          cvr.cvrNumber(), cvr.id(),
                                                          cvr.ballotType(), location));
-            cvr_set.add(cvr);
           }
+          cvr_set.add(cvr);
         }
         start = end + 1; // end is inclusive
         end = start + (ballot_count - cvr_set.size()) - 1; // end is inclusive

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -1,0 +1,152 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Jul 27, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.endpoint;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.PersistenceException;
+
+import spark.Request;
+import spark.Response;
+
+import us.freeandfair.corla.Main;
+import us.freeandfair.corla.controller.ComparisonAuditController;
+import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
+import us.freeandfair.corla.model.CastVoteRecord;
+import us.freeandfair.corla.model.County;
+import us.freeandfair.corla.model.CountyDashboard;
+import us.freeandfair.corla.persistence.Persistence;
+import us.freeandfair.corla.query.BallotManifestInfoQueries;
+
+/**
+ * The CVR to audit list endpoint.
+ * 
+ * @author Daniel M. Zimmerman
+ * @version 0.0.1
+ */
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class CVRToAuditList extends AbstractEndpoint {
+  /**
+   * The "start" parameter.
+   */
+  public static final String START = "start";
+  
+  /**
+   * The "ballot_count" parameter.
+   */
+  public static final String BALLOT_COUNT = "ballot_count";
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public EndpointType endpointType() {
+    return EndpointType.GET;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String endpointName() {
+    return "/cvr-to-audit-list";
+  }
+  
+  /**
+   * This endpoint requires any kind of authentication.
+   */
+  @Override
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.COUNTY;
+  }
+
+  /**
+   * Validate the request parameters. In this case, the two parameters
+   * must exist and both be non-negative integers.
+   * 
+   * @param the_request The request.
+   */
+  @Override
+  protected boolean validateParameters(final Request the_request) {
+    final String start = the_request.params(START);
+    final String ballot_count = the_request.params(BALLOT_COUNT);
+    
+    boolean result = start != null && ballot_count != null;
+    
+    if (result) {
+      try {
+        final int s = Integer.parseInt(start);
+        result = s >= 0;
+        final int b = Integer.parseInt(ballot_count);
+        result &= b >= 0;
+      } catch (final NumberFormatException e) {
+        result = false;
+      }
+    }
+    
+    return result;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String endpoint(final Request the_request, final Response the_response) {
+    try {
+      // get the request parameters
+      final int index = Integer.parseInt(the_request.params(START));
+      final int ballot_count = Integer.parseInt(the_request.params(BALLOT_COUNT));
+      
+      // get other things we need
+      final County county = Authentication.authenticatedCounty(the_request);
+      final CountyDashboard cdb = Persistence.getByID(county.id(), CountyDashboard.class);
+      final Set<CastVoteRecord> cvr_set = new HashSet<>();
+      final List<CVRToAuditResponse> cvr_to_audit_list = new ArrayList<>();
+      
+      // we need to get the CVRs for the county's sequence, starting at START, and 
+      // look up their locations; note we may have to ask for the sequence more than
+      // once because we may find duplicates in the sequence
+      
+      int start = index;
+      int end = start + ballot_count - 1; // end is inclusive
+      
+      while (cvr_set.size() < ballot_count) {
+        final List<CastVoteRecord> new_cvrs = 
+            ComparisonAuditController.computeBallotOrder(cdb, start, end);
+        for (int i = 0; i < new_cvrs.size(); i++) {
+          final CastVoteRecord cvr = new_cvrs.get(i);
+          if (!cvr_set.contains(cvr)) {
+            // this is legitimately a new CVR
+            final String location = BallotManifestInfoQueries.locationFor(cvr);
+            cvr_to_audit_list.add(new CVRToAuditResponse(start + i, cvr.scannerID(), 
+                                                         cvr.batchID(), cvr.recordID(), 
+                                                         cvr.imprintedID(),
+                                                         cvr.ballotType(), location));
+          }
+        }
+        start = end + 1; // end is inclusive
+        end = start + (ballot_count - cvr_set.size()) - 1; // end is inclusive
+        // at this point, if cvr_set.size() < ballot_count, this is an empty range
+      }
+      
+      cvr_to_audit_list.sort(new BallotOrderComparator());
+      okJSON(the_response, Main.GSON.toJson(cvr_to_audit_list));
+    } catch (final PersistenceException e) {
+      serverError(the_response, "could not generate cvr list");
+    }
+    return my_endpoint_result.get();
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -81,8 +81,8 @@ public class CVRToAuditList extends AbstractEndpoint {
    */
   @Override
   protected boolean validateParameters(final Request the_request) {
-    final String start = the_request.params(START);
-    final String ballot_count = the_request.params(BALLOT_COUNT);
+    final String start = the_request.queryParams(START);
+    final String ballot_count = the_request.queryParams(BALLOT_COUNT);
     
     boolean result = start != null && ballot_count != null;
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -107,8 +107,8 @@ public class CVRToAuditList extends AbstractEndpoint {
   public String endpoint(final Request the_request, final Response the_response) {
     try {
       // get the request parameters
-      final int index = Integer.parseInt(the_request.params(START));
-      final int ballot_count = Integer.parseInt(the_request.params(BALLOT_COUNT));
+      final int index = Integer.parseInt(the_request.queryParams(START));
+      final int ballot_count = Integer.parseInt(the_request.queryParams(BALLOT_COUNT));
       
       // get other things we need
       final County county = Authentication.authenticatedCounty(the_request);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -135,6 +135,7 @@ public class CVRToAuditList extends AbstractEndpoint {
                                                          cvr.batchID(), cvr.recordID(), 
                                                          cvr.imprintedID(),
                                                          cvr.ballotType(), location));
+            cvr_set.add(cvr);
           }
         }
         start = end + 1; // end is inclusive

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -157,7 +157,7 @@ public class CVRToAuditList extends AbstractEndpoint {
             ComparisonAuditController.computeBallotOrder(cdb, start, end);
         for (int i = 0; i < new_cvrs.size(); i++) {
           final CastVoteRecord cvr = new_cvrs.get(i);
-          if ((duplicates || !cvr_set.contains(cvr)) && notAudited(cvr)) {
+          if ((duplicates || !cvr_set.contains(cvr)) && notAudited(cdb, cvr)) {
             // get the CVR location
             final String location = BallotManifestInfoQueries.locationFor(cvr);
             cvr_to_audit_list.add(new CVRToAuditResponse(start + i, cvr.scannerID(), 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -51,6 +51,16 @@ public class CVRToAuditResponse {
   protected final String my_imprinted_id;
   
   /**
+   * The CVR number (from the CSV file).
+   */
+  protected final int my_cvr_number;
+  
+  /**
+   * The CVR database ID.
+   */
+  protected final long my_db_id;
+  
+  /**
    * The CVR ballot type.
    */
   protected final String my_ballot_type;
@@ -68,6 +78,8 @@ public class CVRToAuditResponse {
    * @param the_batch_id The batch ID.
    * @param the_record_id The record ID.
    * @param the_imprinted_id The imprinted ID.
+   * @param the_cvr_number The CVR number (from the CSV file).
+   * @param the_db_id The database ID.
    * @param the_ballot_type The ballot type.
    * @param the_storage_location The storage location.
    */
@@ -76,6 +88,8 @@ public class CVRToAuditResponse {
                             final int the_batch_id,
                             final int the_record_id,
                             final String the_imprinted_id,
+                            final int the_cvr_number,
+                            final long the_db_id,
                             final String the_ballot_type,
                             final String the_storage_location) {
     my_audit_sequence_number = the_audit_sequence_number;
@@ -83,6 +97,8 @@ public class CVRToAuditResponse {
     my_batch_id = the_batch_id;
     my_record_id = the_record_id;
     my_imprinted_id = the_imprinted_id;
+    my_cvr_number = the_cvr_number;
+    my_db_id = the_db_id;
     my_ballot_type = the_ballot_type;
     my_storage_location = the_storage_location;
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -22,7 +22,8 @@ import us.freeandfair.corla.util.SuppressFBWarnings;
  * @version 0.0.1
  */
 @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-@SuppressFBWarnings(value = {"URF_UNREAD_FIELD"}, justification = "Field is read by Gson.")
+@SuppressFBWarnings(value = {"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"}, 
+                    justification = "Field is read by Gson.")
 public class CVRToAuditResponse {
   /**
    * The (first) audit sequence number.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -11,6 +11,7 @@
 
 package us.freeandfair.corla.json;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import us.freeandfair.corla.util.SuppressFBWarnings;
@@ -108,7 +109,13 @@ public class CVRToAuditResponse {
    * then record ID.
    */
   @SuppressWarnings("PMD.AtLeastOneConstructor")
-  public static class BallotOrderComparator implements Comparator<CVRToAuditResponse> {
+  public static class BallotOrderComparator 
+      implements Serializable, Comparator<CVRToAuditResponse> {
+    /**
+     * The serialVersionUID.
+     */
+    private static final long serialVersionUID = 1;
+    
     /**
      * Orders two CVRToAuditResponses lexicographically by the triple
      * (scanner_id, batch_id, record_id).

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -1,0 +1,124 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 10, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.json;
+
+import java.util.Comparator;
+
+import us.freeandfair.corla.util.SuppressFBWarnings;
+
+/**
+ * The standard response provided by the server in response to a request
+ * for CVR locations.
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @version 0.0.1
+ */
+@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+@SuppressFBWarnings(value = {"URF_UNREAD_FIELD"}, justification = "Field is read by Gson.")
+public class CVRToAuditResponse {
+  /**
+   * The (first) audit sequence number.
+   */
+  protected final int my_audit_sequence_number;
+  
+  /**
+   * The CVR scanner ID.
+   */
+  protected final int my_scanner_id;
+  
+  /**
+   * The CVR batch ID.
+   */
+  protected final int my_batch_id;
+ 
+  /**
+   * The CVR record ID.
+   */
+  protected final int my_record_id;
+
+  /**
+   * The CVR imprinted ID.
+   */
+  protected final String my_imprinted_id;
+  
+  /**
+   * The CVR ballot type.
+   */
+  protected final String my_ballot_type;
+
+  /**
+   * The CVR storage location.
+   */
+  protected final String my_storage_location;
+
+  /**
+   * Create a new response object.
+   * 
+   * @param the_audit_sequence_number The audit sequence number.
+   * @param the_scanner_id The scanner ID.
+   * @param the_batch_id The batch ID.
+   * @param the_record_id The record ID.
+   * @param the_imprinted_id The imprinted ID.
+   * @param the_ballot_type The ballot type.
+   * @param the_storage_location The storage location.
+   */
+  public CVRToAuditResponse(final int the_audit_sequence_number,
+                            final int the_scanner_id,
+                            final int the_batch_id,
+                            final int the_record_id,
+                            final String the_imprinted_id,
+                            final String the_ballot_type,
+                            final String the_storage_location) {
+    my_audit_sequence_number = the_audit_sequence_number;
+    my_scanner_id = the_scanner_id;
+    my_batch_id = the_batch_id;
+    my_record_id = the_record_id;
+    my_imprinted_id = the_imprinted_id;
+    my_ballot_type = the_ballot_type;
+    my_storage_location = the_storage_location;
+  }
+  
+  /**
+   * A comparator to sort CVRLocationResponse objects by scanner ID, then batch ID,
+   * then record ID.
+   */
+  @SuppressWarnings("PMD.AtLeastOneConstructor")
+  public static class BallotOrderComparator implements Comparator<CVRToAuditResponse> {
+    /**
+     * Orders two CVRToAuditResponses lexicographically by the triple
+     * (scanner_id, batch_id, record_id).
+     * 
+     * @param the_first The first response.
+     * @param the_second The second response.
+     * @return a positive, negative, or 0 value as the first response is
+     * greater than, equal to, or less than the second, respectively.
+     */
+    @SuppressWarnings("PMD.ConfusingTernary")
+    public int compare(final CVRToAuditResponse the_first, 
+                       final CVRToAuditResponse the_second) {
+      final int scanner = the_first.my_scanner_id - the_second.my_scanner_id;
+      final int batch = the_first.my_batch_id - the_second.my_batch_id;
+      final int record = the_first.my_record_id - the_second.my_record_id;
+      
+      final int result;
+      
+      if (scanner != 0) {
+        result = scanner;
+      } else if (batch != 0) {
+        result = batch;
+      } else {
+        result = record;
+      }
+      
+      return result;
+    }
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/VersionExclusionStrategy.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/VersionExclusionStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 27, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.json;
+
+import javax.persistence.Version;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+/**
+ * An exclusion strategy that excludes our Hibernate version fields from Gson
+ * serialization.
+ * 
+ * @author Daniel M. Zimmerman
+ * @version 0.0.1
+ */
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class VersionExclusionStrategy implements ExclusionStrategy {
+  /**
+   * Don't exclude any classes.
+   * 
+   * @param the_class The class, ignored.
+   */
+  public boolean shouldSkipClass(final Class<?> the_class) {
+    return false;
+  }
+  
+  /**
+   * Exclude fields with the @Version annotation.
+   * 
+   * @param the_field The field attributes.
+   */
+  public boolean shouldSkipField(final FieldAttributes the_field) {
+    return the_field.getAnnotation(Version.class) != null;
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
@@ -74,13 +74,13 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
    * The ID number of the scanner that scanned the batch.
    */
   @Column(updatable = false, nullable = false)
-  private String my_scanner_id;
+  private Integer my_scanner_id;
 
   /**
    * The batch number.
    */
   @Column(updatable = false, nullable = false)
-  private String my_batch_id;
+  private Integer my_batch_id;
   
   /**
    * The size of the batch.
@@ -112,8 +112,8 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
    * @param the_storage_location The storage location.
    */
   public BallotManifestInfo(final Long the_county_id,
-                            final String the_scanner_id, 
-                            final String the_batch_id,
+                            final Integer the_scanner_id, 
+                            final Integer the_batch_id,
                             final int the_batch_size, 
                             final String the_storage_location) {
     super();
@@ -158,14 +158,14 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
   /**
    * @return the scanner ID.
    */
-  public String scannerID() {
+  public Integer scannerID() {
     return my_scanner_id;
   }
   
   /**
    * @return the batch number.
    */
-  public String batchID() {
+  public Integer batchID() {
     return my_batch_id;
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
@@ -31,6 +31,7 @@ import org.hibernate.query.Query;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.model.BallotManifestInfo;
+import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.persistence.Persistence;
 
 /**
@@ -74,6 +75,38 @@ public final class BallotManifestInfoQueries {
       Main.LOGGER.error("Exception when reading ballot manifests from database: " + e);
     }
 
+    return result;
+  }
+  
+  /**
+   * Returns the location for the specified CVR, assuming one can be found.
+   * 
+   * @param the_cvr The CVR.
+   * @return the location for the CVR, or null if no location can be found.
+   */
+  public static String locationFor(final CastVoteRecord the_cvr) {
+    String result = null;
+    
+    try {
+      final Session s = Persistence.currentSession();
+      final CriteriaBuilder cb = s.getCriteriaBuilder();
+      final CriteriaQuery<String> cq = cb.createQuery(String.class);
+      final Root<BallotManifestInfo> root = cq.from(BallotManifestInfo.class);
+      cq.select(root.get("my_location"));
+      cq.where(cb.and(cb.equal(root.get("my_county_id"), the_cvr.countyID()),
+                      cb.equal(root.get("my_scanner_id"), the_cvr.scannerID()),
+                      cb.equal(root.get("my_batch_id"), the_cvr.batchID())));
+      final TypedQuery<String> query = s.createQuery(cq);
+      final List<String> query_result = query.getResultList();
+      // there should never be more than one result, but if there is, we'll 
+      // return the first one
+      if (!query_result.isEmpty()) {
+        result = query_result.get(0);
+      }
+    } catch (final PersistenceException e) {
+      Main.LOGGER.error("Exception when finding ballot location: " + e);
+    }
+    
     return result;
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
@@ -92,7 +92,7 @@ public final class BallotManifestInfoQueries {
       final CriteriaBuilder cb = s.getCriteriaBuilder();
       final CriteriaQuery<String> cq = cb.createQuery(String.class);
       final Root<BallotManifestInfo> root = cq.from(BallotManifestInfo.class);
-      cq.select(root.get("my_location"));
+      cq.select(root.get("my_storage_location"));
       cq.where(cb.and(cb.equal(root.get("my_county_id"), the_cvr.countyID()),
                       cb.equal(root.get("my_scanner_id"), the_cvr.scannerID()),
                       cb.equal(root.get("my_batch_id"), the_cvr.batchID())));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
@@ -280,7 +280,7 @@ public final class CastVoteRecordQueries {
     }
     if (result == null) {
       Main.LOGGER.debug("found no CVR for county " + the_county_id +
-                        ", type " + the_type);
+                        ", type " + the_type + ", sequence " + the_sequence_number);
     } else {
       Main.LOGGER.debug("found CVR " + result);
     }

--- a/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
+++ b/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
@@ -21,6 +21,7 @@ us.freeandfair.corla.endpoint.CVRDownloadByCounty
 us.freeandfair.corla.endpoint.CVRDownloadByID
 us.freeandfair.corla.endpoint.CVRExportImport
 us.freeandfair.corla.endpoint.CVRExportUpload
+us.freeandfair.corla.endpoint.CVRToAuditList
 us.freeandfair.corla.endpoint.DoSDashboardASMState
 us.freeandfair.corla.endpoint.DoSDashboardRefresh
 us.freeandfair.corla.endpoint.EstablishAuditBoard


### PR DESCRIPTION
Adds an endpoint to retrieve the list of CVRs to audit, sorted by ballot order, by specifying a starting index (`start`) and a ballot count (`ballot_count`) as HTTP request parameters.