### PR TITLE
Rounds on the Server Side

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AuditBoardDashboardASM.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/AuditBoardDashboardASM.java
@@ -40,7 +40,8 @@ public class AuditBoardDashboardASM extends AbstractStateMachine {
    * The final states of this ASM.
    */
   private static final ASMState[] FINAL_STATES = 
-      {AuditBoardDashboardState.AUDIT_REPORT_SUBMITTED};
+      {AuditBoardDashboardState.AUDIT_REPORT_SUBMITTED,
+       AuditBoardDashboardState.UNABLE_TO_AUDIT};
   
   /**
    * Create the Audit Board Dashboard ASM for the specified county.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -175,8 +175,6 @@ public final class ComparisonAuditController {
     }
     
     the_dashboard.setAuditedPrefixLength(0);
-    the_dashboard.setDiscrepancies(0);
-    the_dashboard.setDisagreements(0);
     for (final CountyContestResult ccr : 
          CountyContestResultQueries.forCounty(the_dashboard.county())) {
       final CountyContestComparisonAudit audit = 
@@ -321,14 +319,14 @@ public final class ComparisonAuditController {
     if (the_update_counters) {
       the_dashboard.setBallotsAudited(the_dashboard.ballotsAudited() + 1); 
       if (discrepancy_found) {
-        the_dashboard.setDiscrepancies(the_dashboard.discrepancies() + 1);
+        the_dashboard.addDiscrepancy();
       }
       boolean disagree = false;
       for (final CVRContestInfo ci : the_audit_cvr.contestInfo()) {
         disagree |= ci.consensus() == ConsensusValue.NO;
       }
       if (disagree) {
-        the_dashboard.setDisagreements(the_dashboard.disagreements() + 1);
+        the_dashboard.addDisagreement();
       }
     }
   }
@@ -357,14 +355,14 @@ public final class ComparisonAuditController {
     }
     the_dashboard.setBallotsAudited(the_dashboard.ballotsAudited() - 1); 
     if (discrepancy_found) {
-      the_dashboard.setDiscrepancies(the_dashboard.discrepancies() - 1);
+      the_dashboard.removeDiscrepancy();
     }
     boolean disagree = false;
     for (final CVRContestInfo ci : the_audit_cvr.contestInfo()) {
       disagree |= ci.consensus() == ConsensusValue.NO;
     }
     if (disagree) {
-      the_dashboard.setDisagreements(the_dashboard.disagreements() - 1);
+      the_dashboard.removeDisagreement();
     }
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -32,6 +32,7 @@ import us.freeandfair.corla.model.CountyContestComparisonAudit;
 import us.freeandfair.corla.model.CountyContestResult;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.model.DoSDashboard;
+import us.freeandfair.corla.model.Round;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.CVRAuditInfoQueries;
 import us.freeandfair.corla.query.CastVoteRecordQueries;
@@ -189,6 +190,7 @@ public final class ComparisonAuditController {
     }
     the_dashboard.setComparisonAudits(comparison_audits);
     the_dashboard.setDrivingContests(county_driving_contests);
+    the_dashboard.startRound(to_audit, 0);
     the_dashboard.setEstimatedBallotsToAudit(Math.max(0,  to_audit));
     if (!county_driving_contests.isEmpty()) {
       the_dashboard.setCVRsToAudit(computeBallotOrder(the_dashboard, 0, to_audit));
@@ -394,6 +396,10 @@ public final class ComparisonAuditController {
       the_dashboard.addCVRsToAudit(new_cvrs);
     }
     the_dashboard.setAuditedPrefixLength(new_prefix_length);
+    final Round current_round = the_dashboard.currentRound();
+    if (current_round.startIndex() + current_round.numberOfBallots() <= new_prefix_length) {
+      the_dashboard.endRound();
+    }
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -379,7 +379,7 @@ public final class ComparisonAuditController {
       discrepancy_found |= discrepancy != 0;
     }
     if (the_update_counters) {
-      the_dashboard.setBallotsAudited(the_dashboard.ballotsAudited() + 1); 
+      the_dashboard.addAuditedBallot();
       if (discrepancy_found) {
         the_dashboard.addDiscrepancy();
       }
@@ -415,7 +415,7 @@ public final class ComparisonAuditController {
       }
       discrepancy_found |= discrepancy != 0;
     }
-    the_dashboard.setBallotsAudited(the_dashboard.ballotsAudited() - 1); 
+    the_dashboard.addAuditedBallot(); 
     if (discrepancy_found) {
       the_dashboard.removeDiscrepancy();
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
@@ -14,7 +14,6 @@ package us.freeandfair.corla.endpoint;
 import static us.freeandfair.corla.asm.ASMEvent.AuditBoardDashboardEvent.REPORT_MARKINGS_EVENT;
 
 import java.time.Instant;
-import java.util.OptionalLong;
 
 import javax.persistence.PersistenceException;
 
@@ -31,7 +30,6 @@ import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.persistence.Persistence;
-import us.freeandfair.corla.query.CastVoteRecordQueries;
 
 /**
  * The "audit CVR upload" endpoint.
@@ -88,11 +86,6 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
         Persistence.saveOrUpdate(real_acvr);
         Main.LOGGER.info("Audit CVR for CVR id " + submission.cvrID() + 
                          " parsed and stored as id " + real_acvr.id());
-        final OptionalLong count = 
-            CastVoteRecordQueries.countMatching(RecordType.AUDITOR_ENTERED);
-        if (count.isPresent()) {
-          Main.LOGGER.info(count.getAsLong() + " ACVRs in storage");
-        }
         final CountyDashboard cdb = 
             Persistence.getByID(Authentication.authenticatedCounty(the_request).id(),
                                 CountyDashboard.class);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditReport.java
@@ -93,6 +93,9 @@ public class AuditReport extends AbstractAuditBoardDashboardEndpoint {
       final CountyDashboard cdb = 
           Persistence.getByID(Authentication.authenticatedCounty(the_request).id(), 
                               CountyDashboard.class);
+      if (cdb.currentRound() != null) {
+        cdb.endRound();
+      }
       cdb.signOutAuditBoard();
       ok(the_response, "Final audit report saved (actual action to be specified by CDOS)");
     } catch (final IllegalStateException e) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
@@ -216,8 +216,9 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
           invariantViolation(the_response, "no previous audit rounds for county " + cdb.id());
         } else {
           final Round previous_round = rounds.get(rounds.size() - 1);
-          // we start the next round where the previous round actually ended
-          start_index = previous_round.startIndex() + previous_round.actualCount();
+          // we start the next round where the previous round actually ended 
+          // in the audit sequence
+          start_index = previous_round.auditPrefixLengthAchieved();
         }
         final int round_length;
         if (start.useEstimates()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
@@ -188,7 +188,7 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
     try {
       // first, figure out what counties we need to do this for, if the list is limited
       final List<CountyDashboard> cdbs;
-      if (start.countyBallots() == null) {
+      if (start.countyBallots().isEmpty()) {
         cdbs = Persistence.getAll(CountyDashboard.class);
       } else {
         cdbs = new ArrayList<>();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
@@ -1,0 +1,213 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 12, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @creator Joe Kiniry <kiniry@freeandfair.us>
+ * @description A system to assist in conducting statewide
+ * risk-limiting audits.
+ */
+
+package us.freeandfair.corla.endpoint;
+import static us.freeandfair.corla.asm.ASMEvent.AuditBoardDashboardEvent.*;
+import static us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent.*;
+import static us.freeandfair.corla.asm.ASMEvent.DoSDashboardEvent.PUBLISH_BALLOTS_TO_AUDIT_EVENT;
+import static us.freeandfair.corla.asm.ASMState.DoSDashboardState.RANDOM_SEED_PUBLISHED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.PersistenceException;
+
+import com.google.gson.JsonSyntaxException;
+
+import spark.Request;
+import spark.Response;
+
+import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
+import us.freeandfair.corla.asm.ASMState.CountyDashboardState;
+import us.freeandfair.corla.asm.ASMUtilities;
+import us.freeandfair.corla.asm.AuditBoardDashboardASM;
+import us.freeandfair.corla.asm.CountyDashboardASM;
+import us.freeandfair.corla.controller.ComparisonAuditController;
+import us.freeandfair.corla.json.SubmittedAuditRoundStart;
+import us.freeandfair.corla.model.CountyDashboard;
+import us.freeandfair.corla.model.Round;
+import us.freeandfair.corla.persistence.Persistence;
+
+/**
+ * Starts a new audit round for one or more counties.
+ * 
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @version 0.0.1
+ */
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class StartAuditRound extends AbstractDoSDashboardEndpoint {
+  /**
+   * The event to return for this endpoint.
+   */
+  private final ThreadLocal<ASMEvent> my_event = new ThreadLocal<ASMEvent>();
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public EndpointType endpointType() {
+    return EndpointType.POST;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String endpointName() {
+    return "/start-audit-round";
+  }
+
+  /**
+   * @return STATE authorization is necessary for this endpoint.
+   */
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.STATE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected ASMEvent endpointEvent() {
+    return my_event.get();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String endpoint(final Request the_request,
+                         final Response the_response) {
+    if (my_asm.get().currentState() == RANDOM_SEED_PUBLISHED) {
+      // the audit hasn't started yet, so start round 1 and ignore the parameters
+      // we were sent
+      my_event.set(PUBLISH_BALLOTS_TO_AUDIT_EVENT);
+      return startRoundOne(the_request, the_response);
+    } else {
+      // start a subsequent round
+      my_event.set(null);
+      return startSubsequentRound(the_request, the_response);
+    }
+  }
+  
+  /**
+   * Starts the first audit round.
+   * 
+   * @param the_request The HTTP request.
+   * @param the_response The HTTP response.
+   * @return the result for endpoint.
+   */
+  public String startRoundOne(final Request the_request, final Response the_response) {
+    // update every county dashboard with a list of ballots to audit
+    try {
+      final List<CountyDashboard> cdbs = Persistence.getAll(CountyDashboard.class);
+      
+      for (final CountyDashboard cdb : cdbs) {
+        try {
+          if (cdb.cvrUploadTimestamp() == null) {
+            Main.LOGGER.info("county " + cdb.id() + " missed the file upload deadline");
+          } else {
+            // find the initial window
+            ComparisonAuditController.initializeAuditData(cdb);
+            Main.LOGGER.info("county " + cdb.id() + " initially estimated to audit " + 
+                             cdb.estimatedBallotsToAudit() + " ballots");
+            Persistence.saveOrUpdate(cdb);
+          } 
+          // update the ASMs for the county and audit board
+          if (!DISABLE_ASM) {
+            final CountyDashboardASM asm = 
+                ASMUtilities.asmFor(CountyDashboardASM.class, String.valueOf(cdb.id()));
+            asm.stepEvent(COUNTY_START_AUDIT_EVENT);
+            final ASMEvent audit_event;
+            if (asm.currentState().equals(CountyDashboardState.COUNTY_AUDIT_UNDERWAY) &&
+                cdb.comparisonAudits().isEmpty()) {
+              // the county made its deadline but was assigned no contests to audit
+              audit_event = NO_CONTESTS_TO_AUDIT_EVENT;
+              asm.stepEvent(COUNTY_AUDIT_COMPLETE_EVENT);
+            } else if (asm.currentState().equals(CountyDashboardState.COUNTY_AUDIT_UNDERWAY)) {
+              // the audit started normally
+              audit_event = AUDIT_BOARD_START_AUDIT_EVENT;
+            } else {
+              // the county missed its deadline
+              audit_event = COUNTY_DEADLINE_MISSED_EVENT;
+            }
+            ASMUtilities.step(audit_event, AuditBoardDashboardASM.class,
+                              String.valueOf(cdb.id()));
+            ASMUtilities.save(asm);
+          }
+        } catch (final IllegalArgumentException e) {
+          e.printStackTrace(System.out);
+          serverError(the_response, "could not start round 1 for county " + 
+                      cdb.id());
+          Main.LOGGER.info("could not start round 1 for county " + cdb.id());
+        }
+      }
+      
+      ok(the_response, "round 1 started");
+    } catch (final PersistenceException e) {
+      serverError(the_response, "could not start round 1");
+    }
+    
+    return my_endpoint_result.get();
+  }
+
+  /**
+   * Starts a subsequent audit round.
+   * 
+   * @param the_request The HTTP request.
+   * @param the_response The HTTP response.
+   * @return the result for endpoint.
+   */
+  public String startSubsequentRound(final Request the_request, final Response the_response) {
+    SubmittedAuditRoundStart start = null;
+    try {
+      start = Main.GSON.fromJson(the_request.body(), SubmittedAuditRoundStart.class);
+    } catch (final JsonSyntaxException e) {
+      badDataContents(the_response, "malformed request data");
+    }
+    
+    try {
+      // first, figure out what counties we need to do this for, if the list is limited
+      final List<CountyDashboard> cdbs;
+      if (start.countyBallots() == null) {
+        cdbs = Persistence.getAll(CountyDashboard.class);
+      } else {
+        cdbs = new ArrayList<>();
+        for (final Long id : start.countyBallots().keySet()) {
+          cdbs.add(Persistence.getByID(id, CountyDashboard.class));
+        }
+      }
+    
+      for (final CountyDashboard cdb : cdbs) {
+        // if the county is in the middle of a round, error out
+        if (cdb.currentRound() != null) {
+          invariantViolation(the_response, "audit round already in progress for county " + cdb.id());
+        }
+        final List<Round> previous_rounds = cdb.rounds();
+        int start_index;
+        if (!previous_rounds.isEmpty() && 
+        final int round_length;
+        if (start.useEstimates()) {
+          // use estimates based on current error rate to get length of round
+          round_length 
+        }
+      }
+      
+      ok(the_response, "ballot lists published");
+    } catch (final PersistenceException e) {
+      serverError(the_response, "could not publish list of ballots to audit");
+    }
+    
+    return my_endpoint_result.get();
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -31,6 +31,7 @@ import us.freeandfair.corla.model.ContestToAudit.AuditType;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.model.DoSDashboard;
+import us.freeandfair.corla.model.Round;
 import us.freeandfair.corla.model.UploadedFile;
 import us.freeandfair.corla.model.UploadedFile.FileStatus;
 import us.freeandfair.corla.persistence.Persistence;
@@ -154,6 +155,11 @@ public class CountyDashboardRefreshResponse {
    */
   private final Integer my_audited_prefix_length;
   
+  /** 
+   * The current audit round.
+   */
+  private final Round my_current_round;
+  
   /**
    * Constructs a new CountyDashboardRefreshResponse.
    * 
@@ -174,8 +180,9 @@ public class CountyDashboardRefreshResponse {
    * @param the_ballot_under_audit_id The ID of the CVR under audit.
    * @param the_audited_prefix_length The length of the audited prefix of the
    * ballots to audit list.
+   * @param the_current_round The current audit round.
    */
-  @SuppressWarnings("PMD.ExcessiveParameterList")
+  @SuppressWarnings({"PMD.ExcessiveParameterList", "checkstyle:executablestatementcount"})
   protected CountyDashboardRefreshResponse(final Long the_id,
                                            final ASMState the_asm_state,
                                            final Map<String, String> the_general_information,
@@ -195,7 +202,8 @@ public class CountyDashboardRefreshResponse {
                                            final Integer the_disagreement_count,
                                            final List<Long> the_ballots_to_audit,
                                            final Long the_ballot_under_audit_id,
-                                           final Integer the_audited_prefix_length) {
+                                           final Integer the_audited_prefix_length,
+                                           final Round the_current_round) {
     my_id = the_id;
     my_asm_state = the_asm_state;
     my_general_information = the_general_information;
@@ -216,6 +224,7 @@ public class CountyDashboardRefreshResponse {
     my_ballots_to_audit = the_ballots_to_audit;
     my_ballot_under_audit_id = the_ballot_under_audit_id;
     my_audited_prefix_length = the_audited_prefix_length;
+    my_current_round = the_current_round;
   }
   
   /**
@@ -303,7 +312,8 @@ public class CountyDashboardRefreshResponse {
                                               the_dashboard.disagreements(),
                                               CVRAuditInfoQueries.cvrsToAudit(the_dashboard),
                                               the_dashboard.cvrUnderAudit(),
-                                              the_dashboard.auditedPrefixLength());
+                                              the_dashboard.auditedPrefixLength(),
+                                              the_dashboard.currentRound());
   }
   
   /**
@@ -373,6 +383,7 @@ public class CountyDashboardRefreshResponse {
                                               the_dashboard.disagreements(),
                                               null,
                                               null,
-                                              null);
+                                              the_dashboard.auditedPrefixLength(),
+                                              the_dashboard.currentRound());
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -115,15 +115,18 @@ public class CountyDashboardRefreshResponse {
   
   /**
    * The date and time of the audit. 
-   * @todo connect this to something
    */
   private final Instant my_audit_time;
   
   /**
    * The estimated number of ballots to audit.
-   * @todo connect this to something
    */
   private final Integer my_estimated_ballots_to_audit;
+  
+  /**
+   * The ballots remaining in the round.
+   */
+  private final Integer my_ballots_remaining_in_round;
   
   /**
    * The number of ballots audited.
@@ -173,6 +176,8 @@ public class CountyDashboardRefreshResponse {
    * @param the_contests_under_audit The contests under audit, with reasons.
    * @param the_audit_time The audit time.
    * @param the_estimated_ballots_to_audit The estimated ballots to audit.
+   * @param the_ballots_remaining_in_round The ballots remaining in the 
+   * current round.
    * @param the_audited_ballot_count The number of ballots audited.
    * @param the_discrepancy_count The number of discrepencies.
    * @param the_disagreement_count The number of disagreements.
@@ -197,6 +202,7 @@ public class CountyDashboardRefreshResponse {
                                            final Map<Long, String> the_contests_under_audit,
                                            final Instant the_audit_time,
                                            final Integer the_estimated_ballots_to_audit,
+                                           final Integer the_ballots_remaining_in_round,
                                            final Integer the_audited_ballot_count,
                                            final Integer the_discrepancy_count, 
                                            final Integer the_disagreement_count,
@@ -218,6 +224,7 @@ public class CountyDashboardRefreshResponse {
     my_contests_under_audit = the_contests_under_audit;
     my_audit_time = the_audit_time;
     my_estimated_ballots_to_audit = the_estimated_ballots_to_audit;
+    my_ballots_remaining_in_round = the_ballots_remaining_in_round;
     my_audited_ballot_count = the_audited_ballot_count;
     my_discrepancy_count = the_discrepancy_count;
     my_disagreement_count = the_disagreement_count;
@@ -307,6 +314,7 @@ public class CountyDashboardRefreshResponse {
                                               contests_under_audit,
                                               the_dashboard.auditTimestamp(),
                                               the_dashboard.estimatedBallotsToAudit(),
+                                              the_dashboard.ballotsRemainingInCurrentRound(),
                                               the_dashboard.ballotsAudited(),
                                               the_dashboard.discrepancies(),
                                               the_dashboard.disagreements(),
@@ -363,7 +371,7 @@ public class CountyDashboardRefreshResponse {
     // status
     final CountyDashboardASM asm = ASMUtilities.asmFor(CountyDashboardASM.class, 
                                                        county_id.toString());
-
+    
     return new CountyDashboardRefreshResponse(county_id, 
                                               asm.currentState(),
                                               null,
@@ -378,6 +386,7 @@ public class CountyDashboardRefreshResponse {
                                               null,
                                               the_dashboard.auditTimestamp(),
                                               the_dashboard.estimatedBallotsToAudit(),
+                                              the_dashboard.ballotsRemainingInCurrentRound(),
                                               the_dashboard.ballotsAudited(),
                                               the_dashboard.discrepancies(),
                                               the_dashboard.disagreements(),

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/SubmittedAuditRoundStart.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/SubmittedAuditRoundStart.java
@@ -1,0 +1,83 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 13, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.json;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Data submitted to start an audit round.
+ * 
+ * @author Daniel M. Zimmerman
+ * @version 0.0.1
+ */
+public class SubmittedAuditRoundStart {
+  /**
+   * The multiplier for the number of ballots per county.
+   */
+  private final BigDecimal my_multiplier;
+  
+  /**
+   * A flag indicating whether to use the minimum estimates as the base
+   * for each county.
+   */
+  private final Boolean my_use_estimates;
+  
+  /**
+   * A mapping from county IDs to numbers of ballots per county. 
+   */
+  private final Map<Long, Integer> my_county_ballots;
+  
+  /**
+   * Constructs a new SubmittedAuditRoundStart.
+   * 
+   * @param the_multiplier The multiplier. Ignored if using absolute numbers
+   * of ballots.
+   * @param the_use_estimates True to use algorithm estimates, false to use
+   * absolute numbers of ballots.
+   * @param the_ballots_per_county A map from county IDs to absolute numbers
+   * of ballots per county.
+   */
+  public SubmittedAuditRoundStart(final BigDecimal the_multiplier,
+                                  final Boolean the_use_estimates,
+                                  final Map<Long, Integer> the_county_ballots) {
+    my_multiplier = the_multiplier;
+    my_use_estimates = the_use_estimates;
+    my_county_ballots = the_county_ballots;
+  }
+  
+  /**
+   * @return the multiplier.
+   */
+  public BigDecimal multiplier() {
+    return my_multiplier;
+  }
+  
+  /**
+   * @return true if we are using minimum estimates, false otherwise.
+   */
+  public boolean useEstimates() {
+    if (my_use_estimates == null) {
+      return false; 
+    } else {
+      return my_use_estimates;
+    }
+  }
+  
+  /**
+   * @return the map from county IDs to absolute numbers of ballots per county.
+   */
+  public Map<Long, Integer> countyBallots() {
+    return Collections.unmodifiableMap(my_county_ballots);
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
@@ -64,34 +64,59 @@ public class CountyContestComparisonAudit implements PersistentEntity, Serializa
    * Gamma, as presented in the literature:
    * https://www.stat.berkeley.edu/~stark/Preprints/gentle12.pdf
    */
-  public static final BigDecimal GENTLE_GAMMA = BigDecimal.valueOf(1.03905);
-
+  public static final BigDecimal STARK_GAMMA = BigDecimal.valueOf(1.03905);
+  
   /**
    * Gamma, as recommended by Neal McBurnett for use in Colorado.
    */
   public static final BigDecimal COLORADO_GAMMA = BigDecimal.valueOf(1.1);
-
+  
   /**
-   * The initial estimate of error rates for one-vote over- and understatements.
+   * Conservative estimate of error rates for one-vote over- and understatements.
    */
   public static final BigDecimal CONSERVATIVE_ONES_RATE = BigDecimal.valueOf(0.01);
   
   /**
-   * The initial estimate of error rates for two-vote over- and understatements.
+   * Conservative estimate of error rates for two-vote over- and understatements.
    */
   public static final BigDecimal CONSERVATIVE_TWOS_RATE = BigDecimal.valueOf(0.01);
   
   /**
-   * Rounding up of 1-vote over/understatements for the initial estimate of 
-   * error rates.
+   * Conservative rounding up of 1-vote over/understatements for the initial 
+   * estimate of error rates.
    */
   public static final boolean CONSERVATIVE_ROUND_ONES_UP = true;
   
   /**
-   * Rounding up of 2-vote over/understatements for the initial estimate of 
-   * error rates.
+   * Conservative rounding up of 2-vote over/understatements for the initial 
+   * estimate of  error rates.
    */
   public static final boolean CONSERVATIVE_ROUND_TWOS_UP = true;
+  
+  /**
+   * The gamma to use.
+   */
+  public static final BigDecimal GAMMA = STARK_GAMMA;
+  
+  /**
+   * The initial estimate of error rates for one-vote over- and understatements.
+   */
+  public static final BigDecimal ONES_RATE = BigDecimal.ZERO;
+  
+  /**
+   * The initial estimate of error rates for two-vote over- and understatements.
+   */
+  public static final BigDecimal TWOS_RATE = BigDecimal.ZERO;
+  
+  /**
+   * The initial rounding up of 1-vote over/understatements.
+   */
+  public static final boolean ROUND_ONES_UP = false;
+  
+  /**
+   * The initial rounding up of 2-vote over/understatements.
+   */
+  public static final boolean ROUND_TWOS_UP = false;
   
   /**
    * The serialVersionUID.
@@ -138,7 +163,7 @@ public class CountyContestComparisonAudit implements PersistentEntity, Serializa
    */
   @Column(updatable = false, nullable = false, 
           precision = PRECISION, scale = SCALE)
-  private BigDecimal my_gamma = COLORADO_GAMMA;
+  private BigDecimal my_gamma = GAMMA;
   
   /**
    * The risk limit.
@@ -275,12 +300,8 @@ public class CountyContestComparisonAudit implements PersistentEntity, Serializa
   public int initialBallotsToAudit() {
     // compute the conservative numbers of over/understatements based on 
     // initial estimate of error rate
-    return computeBallotsToAuditFromRates(CONSERVATIVE_TWOS_RATE,
-                                          CONSERVATIVE_ONES_RATE,
-                                          CONSERVATIVE_ONES_RATE,
-                                          CONSERVATIVE_TWOS_RATE, 
-                                          CONSERVATIVE_ROUND_ONES_UP,
-                                          CONSERVATIVE_ROUND_TWOS_UP).intValue();
+    return computeBallotsToAuditFromRates(TWOS_RATE, ONES_RATE, ONES_RATE, TWOS_RATE, 
+                                          ROUND_ONES_UP, ROUND_TWOS_UP).intValue();
   }
   
   /**
@@ -299,7 +320,7 @@ public class CountyContestComparisonAudit implements PersistentEntity, Serializa
    * @return the expected number of ballots remaining to audit, assuming 
    * over- and understatement rates continue as they currently are.
    */
-  public int expectedBallotsRemainingToAudit() {
+  public int expectedBallotsToAuditFromCurrentRates() {
     return computeBallotsToAuditFromProgress(my_two_vote_under, my_one_vote_under,
                                              my_one_vote_over, my_two_vote_over,
                                              my_dashboard.auditedPrefixLength());
@@ -405,9 +426,8 @@ public class CountyContestComparisonAudit implements PersistentEntity, Serializa
     final BigDecimal bta = 
         computeBallotsToAuditFromRates(two_under_rate, one_under_rate, 
                                        one_over_rate, two_over_rate,
-                                       CONSERVATIVE_ROUND_ONES_UP, CONSERVATIVE_ROUND_TWOS_UP);
-    final BigDecimal remaining = bta.subtract(BigDecimal.valueOf(the_number_audited));
-    return remaining.setScale(0, RoundingMode.CEILING).intValue();
+                                       ROUND_ONES_UP, ROUND_TWOS_UP);
+    return bta.setScale(0, RoundingMode.CEILING).intValue();
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestResult.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestResult.java
@@ -431,10 +431,15 @@ public class CountyContestResult implements PersistentEntity, Serializable {
     my_min_margin = Integer.MAX_VALUE;
     my_max_margin = Integer.MIN_VALUE;
     for (final String w : my_winners) {
-      for (final String l : my_losers) {
-        final int margin = my_vote_totals.get(w) - my_vote_totals.get(l);
-        my_min_margin = Math.min(my_min_margin, margin);
-        my_max_margin = Math.max(my_max_margin, margin);
+      if (my_losers.isEmpty()) {
+        my_min_margin = 0;
+        my_max_margin = 0;
+      } else {
+        for (final String l : my_losers) {
+          final int margin = my_vote_totals.get(w) - my_vote_totals.get(l);
+          my_min_margin = Math.min(my_min_margin, margin);
+          my_max_margin = Math.max(my_max_margin, margin);
+        }
       }
     }
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -542,7 +542,8 @@ public class CountyDashboard implements PersistentEntity, Serializable {
       result = 0;
     } else {
       final Round round = currentRound();
-      result = round.expectedCount() - round.actualCount();
+      result = round.startIndex() + round.expectedCount() -
+               my_audited_prefix_length; 
     }
     
     return result;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -378,7 +378,7 @@ public class CountyDashboard implements PersistentEntity, Serializable {
    * 
    * @param the_members The members.
    */
-  public void signInAuditBoard(final Set<Elector> the_members) {
+  public void signInAuditBoard(final List<Elector> the_members) {
     if (my_current_audit_board_index == null) {
       my_current_audit_board_index = my_audit_boards.size();
     } else {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -474,7 +474,9 @@ public class CountyDashboard implements PersistentEntity, Serializable {
       my_rounds.get(my_current_round_index).setEndTime(Instant.now());
       my_current_round_index = my_current_round_index + 1;
     }
-    final Round round = new Round(Instant.now(), the_number_of_ballots, the_start_index);
+    // note UI round indexing is from 1, not 0
+    final Round round = new Round(my_current_round_index + 1, Instant.now(), 
+                                  the_number_of_ballots, the_start_index);
     my_rounds.add(round);
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -481,6 +481,10 @@ public class CountyDashboard implements PersistentEntity, Serializable {
                                   the_number_of_ballots, the_start_index);
     updateRound(round);
     my_rounds.add(round);
+    if (round.startIndex() + round.expectedCount() - 1 < auditedPrefixLength()) {
+      // the round ended before it started
+      endRound();
+    }
   }
   
   /**
@@ -491,7 +495,8 @@ public class CountyDashboard implements PersistentEntity, Serializable {
    */
   private void updateRound(final Round the_round) {
     int index = the_round.startIndex();
-    while (index < my_audited_prefix_length) {
+    final int end = the_round.startIndex() + the_round.expectedCount() - 1;
+    while (index < my_audited_prefix_length && index < end) {
       final CVRAuditInfo cvrai = my_cvr_audit_info.get(index);
       for (final CountyContestComparisonAudit ca : comparisonAudits()) {
         if (ca.computeDiscrepancy(cvrai.cvr(), cvrai.acvr()) != 0) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -487,7 +487,9 @@ public class CountyDashboard implements PersistentEntity, Serializable {
     if (my_current_round_index == null) {
       throw new IllegalStateException("no round to end");
     } else {
-      my_rounds.get(my_current_round_index).setEndTime(Instant.now());
+      final Round round = my_rounds.get(my_current_round_index);
+      round.setActualCount(my_audited_prefix_length - round.startIndex());
+      round.setEndTime(Instant.now());
       my_current_round_index = NO_CONTENT;
     }
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -1,0 +1,162 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Jul 25, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @author Joey Dodds <jdodds@galois.com>
+ * @model_review Joe Kiniry <kiniry@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.model;
+
+import static us.freeandfair.corla.util.EqualsHashcodeHelper.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+/**
+ * Information about an audit round. 
+ * 
+ * @author Daniel M. Zimmerman
+ * @version 0.0.1
+ */
+@Embeddable
+// this class has many fields that would normally be declared final, but
+// cannot be for compatibility with Hibernate and JPA.
+@SuppressWarnings("PMD.ImmutableField")
+public class Round implements Serializable {
+  /**
+   * The serialVersionUID.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * The start time.
+   */
+  @Column(nullable = false, updatable = false)
+  private Instant my_start_time;
+
+  /**
+   * The end time.
+   */
+  private Instant my_end_time;
+
+  /**
+   * The number of ballots to audit in this round.
+   */
+  @Column(nullable = false, updatable = false)
+  private Integer my_number_of_ballots;
+  
+  /**
+   * The index of the audit random sequence where the round starts.
+   */
+  @Column(nullable = false, updatable = false)
+  private Integer my_start_index;
+  
+  /**
+   * Constructs an empty round, solely for persistence. 
+   */
+  public Round() {
+    super();
+  }
+    
+  /**
+   * Constructs a round with the specified parameters.
+   * 
+   * @param the_start_time The start time.
+   * @param the_number_of_ballots The number of ballots.
+   * @param the_start_index The index of the audit random sequence 
+   * where the round starts.
+   */
+  public Round(final Instant the_start_time,
+               final Integer the_number_of_ballots,
+               final Integer the_start_index) {
+    super();
+    my_start_time = the_start_time;
+    my_number_of_ballots = the_number_of_ballots;
+    my_start_index = the_start_index;
+  }
+  
+  /**
+   * @return the start time.
+   */
+  public Instant startTime() {
+    return my_start_time;
+  }
+
+  /**
+   * @return the end time.
+   */
+  public Instant endTime() {
+    return my_end_time;
+  }
+  
+  /**
+   * Sets the end time.
+   * 
+   * @param the_end_time The end time.
+   */
+  public void setEndTime(final Instant the_end_time) {
+    my_end_time = the_end_time;
+  }
+  
+  /**
+   * @return the number of ballots to audit.
+   */
+  public Integer numberOfBallots() {
+    return my_number_of_ballots;
+  }
+  
+  /**
+   * @return the index of the audit random sequence where this round
+   * starts.
+   */
+  public Integer startIndex() {
+    return my_start_index;
+  }
+  
+  /**
+   * @return a String representation of this elector.
+   */
+  @Override
+  public String toString() {
+    return "Round [start_time=" + my_start_time + ", end_time=" +
+           my_end_time + ", number_of_ballots=" + my_number_of_ballots + 
+           ", start_index=" + my_start_index + "]";
+  }
+
+  /**
+   * Compare this object with another for equivalence.
+   * 
+   * @param the_other The other object.
+   * @return true if the objects are equivalent, false otherwise.
+   */
+  @Override
+  public boolean equals(final Object the_other) {
+    boolean result = true;
+    if (the_other instanceof Round) {
+      final Round other_round = (Round) the_other;
+      result &= nullableEquals(other_round.startTime(), startTime());
+      result &= nullableEquals(other_round.endTime(), endTime());
+      result &= nullableEquals(other_round.numberOfBallots(), numberOfBallots());
+      result &= nullableEquals(other_round.startIndex(), startIndex());
+    } else {
+      result = false;
+    }
+    return result;
+  }
+  
+  /**
+   * @return a hash code for this object.
+   */
+  @Override
+  public int hashCode() {
+    return nullableHashCode(startTime());
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -66,7 +66,14 @@ public class Round implements Serializable {
    * number is based on the audit random sequence, so it may
    * include duplicate ballots.
    */
+  @Column(nullable = false)
   private Integer my_actual_count;
+  
+  /**
+   * The audited prefix length achieved by the end of this round.
+   */
+  @Column
+  private Integer my_audit_prefix_length_achieved;
   
   /**
    * The index of the audit random sequence where the round starts.
@@ -110,6 +117,7 @@ public class Round implements Serializable {
     my_number = the_number;
     my_start_time = the_start_time;
     my_expected_count = the_expected_count;
+    my_actual_count = 0;
     my_start_index = the_start_index;
   }
   
@@ -158,14 +166,34 @@ public class Round implements Serializable {
   }
   
   /**
-   * Sets the actual number of ballots audited.
-   * 
-   * @param the_actual_count The number of ballots audited; this
-   * should reflect the audit random sequence, not physical 
-   * ballot cards.
+   * @return the audit sequence prefix length achieved by the end of 
+   * this round, or null if this round has not ended.
    */
-  public void setActualCount(final int the_actual_count) {
-    my_actual_count = the_actual_count;
+  public Integer auditPrefixLengthAchieved() {
+    return my_audit_prefix_length_achieved;
+  }
+  
+  /**
+   * Sets the audit prefix sequence length achieved by the end of this round.
+   * 
+   * @param the_audit_prefix_length_achieved The prefix length achieved.
+   */
+  public void setAuditPrefixLengthAchieved(final int the_audit_prefix_length_achieved) {
+    my_audit_prefix_length_achieved = the_audit_prefix_length_achieved;
+  }
+  
+  /**
+   * Adds an audited ballot.
+   */
+  public void addAuditedBallot() {
+    my_actual_count = my_actual_count + 1;
+  }
+  
+  /**
+   * Removes an audited ballot.
+   */
+  public void removeAuditedBallot() {
+    my_actual_count = my_actual_count - 1;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -37,6 +37,12 @@ public class Round implements Serializable {
   private static final long serialVersionUID = 1L;
 
   /**
+   * The round number.
+   */
+  @Column(nullable = false, updatable = false)
+  private Integer my_number;
+  
+  /**
    * The start time.
    */
   @Column(nullable = false, updatable = false)
@@ -78,18 +84,28 @@ public class Round implements Serializable {
   /**
    * Constructs a round with the specified parameters.
    * 
+   * @param the_number The round number.
    * @param the_start_time The start time.
    * @param the_expected_count The expected number of ballots to audit.
    * @param the_start_index The index of the audit random sequence 
    * where the round starts.
    */
-  public Round(final Instant the_start_time,
+  public Round(final Integer the_number,
+               final Instant the_start_time,
                final Integer the_expected_count,
                final Integer the_start_index) {
     super();
+    my_number = the_number;
     my_start_time = the_start_time;
     my_expected_count = the_expected_count;
     my_start_index = the_start_index;
+  }
+  
+  /**
+   * @return the round number.
+   */
+  public Integer number() {
+    return my_number;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -48,10 +48,19 @@ public class Round implements Serializable {
   private Instant my_end_time;
 
   /**
-   * The number of ballots to audit in this round.
+   * The expected number of ballots to audit in this round. This 
+   * number is based on the audit random sequence, so it may
+   * include duplicate ballots.
    */
   @Column(nullable = false, updatable = false)
-  private Integer my_number_of_ballots;
+  private Integer my_expected_count;
+  
+  /**
+   * The actual number of ballots audited in this round. This
+   * number is based on the audit random sequence, so it may
+   * include duplicate ballots.
+   */
+  private Integer my_actual_count;
   
   /**
    * The index of the audit random sequence where the round starts.
@@ -70,16 +79,16 @@ public class Round implements Serializable {
    * Constructs a round with the specified parameters.
    * 
    * @param the_start_time The start time.
-   * @param the_number_of_ballots The number of ballots.
+   * @param the_expected_count The expected number of ballots to audit.
    * @param the_start_index The index of the audit random sequence 
    * where the round starts.
    */
   public Round(final Instant the_start_time,
-               final Integer the_number_of_ballots,
+               final Integer the_expected_count,
                final Integer the_start_index) {
     super();
     my_start_time = the_start_time;
-    my_number_of_ballots = the_number_of_ballots;
+    my_expected_count = the_expected_count;
     my_start_index = the_start_index;
   }
   
@@ -107,10 +116,28 @@ public class Round implements Serializable {
   }
   
   /**
-   * @return the number of ballots to audit.
+   * @return the expected number of ballots to audit.
    */
-  public Integer numberOfBallots() {
-    return my_number_of_ballots;
+  public Integer expectedCount() {
+    return my_expected_count;
+  }
+  
+  /**
+   * @return the actual number of ballots audited.
+   */
+  public Integer actualCount() {
+    return my_actual_count;
+  }
+  
+  /**
+   * Sets the actual number of ballots audited.
+   * 
+   * @param the_actual_count The number of ballots audited; this
+   * should reflect the audit random sequence, not physical 
+   * ballot cards.
+   */
+  public void setActualCount(final int the_actual_count) {
+    my_actual_count = the_actual_count;
   }
   
   /**
@@ -127,8 +154,9 @@ public class Round implements Serializable {
   @Override
   public String toString() {
     return "Round [start_time=" + my_start_time + ", end_time=" +
-           my_end_time + ", number_of_ballots=" + my_number_of_ballots + 
-           ", start_index=" + my_start_index + "]";
+           my_end_time + ", expected_count=" + my_expected_count + 
+           ", actual_count=" + my_actual_count + ", start_index=" + 
+           my_start_index + "]";
   }
 
   /**
@@ -144,7 +172,8 @@ public class Round implements Serializable {
       final Round other_round = (Round) the_other;
       result &= nullableEquals(other_round.startTime(), startTime());
       result &= nullableEquals(other_round.endTime(), endTime());
-      result &= nullableEquals(other_round.numberOfBallots(), numberOfBallots());
+      result &= nullableEquals(other_round.expectedCount(), expectedCount());
+      result &= nullableEquals(other_round.actualCount(), actualCount());
       result &= nullableEquals(other_round.startIndex(), startIndex());
     } else {
       result = false;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -75,6 +75,18 @@ public class Round implements Serializable {
   private Integer my_start_index;
   
   /**
+   * The number of discrepancies.
+   */
+  @Column(nullable = false)
+  private Integer my_discrepancies = 0;
+  
+  /**
+   * The number of disagreements.
+   */
+  @Column(nullable = false)
+  private Integer my_disagreements = 0;
+  
+  /**
    * Constructs an empty round, solely for persistence. 
    */
   public Round() {
@@ -165,6 +177,48 @@ public class Round implements Serializable {
   }
   
   /**
+   * @return the number of discrepancies.
+   */
+  public Integer discrepancies() {
+    return my_discrepancies;
+  }
+  
+  /**
+   * Adds a discrepancy.
+   */
+  public void addDiscrepancy() {
+    my_discrepancies = my_discrepancies + 1;
+  }
+  
+  /**
+   * Removes a discrepancy.
+   */
+  public void removeDiscrepancy() {
+    my_discrepancies = my_discrepancies - 1;
+  }
+  
+  /**
+   * @return the number of disagreements.
+   */
+  public Integer disagreements() {
+    return my_disagreements;
+  }
+  
+  /**
+   * Adds a disagreement.
+   */
+  public void addDisagreement() {
+    my_disagreements = my_disagreements + 1;
+  }
+  
+  /**
+   * Removes a disagreement.
+   */
+  public void removeDisagreement() {
+    my_disagreements = my_disagreements - 1;
+  }
+  
+  /**
    * @return a String representation of this elector.
    */
   @Override
@@ -172,7 +226,8 @@ public class Round implements Serializable {
     return "Round [start_time=" + my_start_time + ", end_time=" +
            my_end_time + ", expected_count=" + my_expected_count + 
            ", actual_count=" + my_actual_count + ", start_index=" + 
-           my_start_index + "]";
+           my_start_index + ", discrepancies=" + my_discrepancies + 
+           "disagreements=" + my_disagreements + "]";
   }
 
   /**
@@ -191,6 +246,8 @@ public class Round implements Serializable {
       result &= nullableEquals(other_round.expectedCount(), expectedCount());
       result &= nullableEquals(other_round.actualCount(), actualCount());
       result &= nullableEquals(other_round.startIndex(), startIndex());
+      result &= nullableEquals(other_round.discrepancies(), discrepancies());
+      result &= nullableEquals(other_round.disagreements(), disagreements());
     } else {
       result = false;
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
@@ -19,6 +19,7 @@ import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaUpdate;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
@@ -81,6 +82,71 @@ public final class CVRAuditInfoQueries {
   }
   
   /**
+   * Updates the CVRAuditInfo objects matching the specified CVR so that they all
+   * have the same ACVR. This assumes that all such objects that have a non-null
+   * ACVR already have the same ACVR, as is the case during an audit when adding
+   * new ballots to the sequence.
+   * 
+   * @param the_dashboard The dashboard to match.
+   * @param the_cvr The CVR to match.
+   * @exception PersistenceException if the objects cannot be updated.
+   */
+  public static void updateMatching(final CountyDashboard the_dashboard,
+                                    final CastVoteRecord the_cvr) {
+    final Session s = Persistence.currentSession();
+    final CriteriaBuilder cb = s.getCriteriaBuilder();
+    final CriteriaQuery<CastVoteRecord> cq = cb.createQuery(CastVoteRecord.class);
+    final Root<CVRAuditInfo> root = cq.from(CVRAuditInfo.class);
+    final List<Predicate> conjuncts = new ArrayList<>();
+    conjuncts.add(cb.equal(root.get("my_dashboard"), the_dashboard));
+    conjuncts.add(cb.equal(root.get("my_cvr"), the_cvr));
+    conjuncts.add(cb.isNotNull(root.get("my_acvr")));
+    cq.select(root.get("my_acvr"));
+    cq.where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
+    final TypedQuery<CastVoteRecord> query = s.createQuery(cq);
+    final List<CastVoteRecord> result = query.getResultList();
+    if (!result.isEmpty()) {
+      final CastVoteRecord acvr = result.get(0);
+      updateMatching(the_dashboard, the_cvr, acvr, true);
+    }
+  }
+
+  /**
+   * Updates the CVRAuditInfo objects matching the specified CVR so that they
+   * all have the specified ACVR. 
+   * 
+   * @param the_dashboard The dashboard to match.
+   * @param the_cvr The CVR to match.
+   * @param the_acvr The ACVR to set.
+   * @param the_null_only true to only update records with null ACVRs 
+   * (as when adding them to the list), false to update all records.
+   * @exception PersistenceException if the objects cannot be updated.
+   */
+  public static void updateMatching(final CountyDashboard the_dashboard,
+                                    final CastVoteRecord the_cvr,
+                                    final CastVoteRecord the_acvr,
+                                    final boolean the_null_only) {
+    final Session s = Persistence.currentSession();
+    final CriteriaBuilder cb = s.getCriteriaBuilder();
+    final CriteriaQuery<CVRAuditInfo> cq = cb.createQuery(CVRAuditInfo.class);
+    final Root<CVRAuditInfo> root = cq.from(CVRAuditInfo.class);
+    final List<Predicate> conjuncts = new ArrayList<>();
+    conjuncts.add(cb.equal(root.get("my_dashboard"), the_dashboard));
+    conjuncts.add(cb.equal(root.get("my_cvr"), the_cvr));
+    if (the_null_only) {
+      conjuncts.add(cb.isNull(root.get("my_acvr")));
+    }
+    cq.select(root);
+    cq.where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
+    final TypedQuery<CVRAuditInfo> query = s.createQuery(cq);
+    final List<CVRAuditInfo> info = query.getResultList();
+    for (final CVRAuditInfo cvrai : info) {
+      cvrai.setACVR(the_acvr);
+      Persistence.saveOrUpdate(cvrai);
+    }  
+  }
+  
+  /**
    * Gets the list of CVR IDs to audit for the specified county dashboard
    * in the current round.
    * 
@@ -99,7 +165,7 @@ public final class CVRAuditInfoQueries {
         final Query query = 
             s.createNativeQuery("select cvr_id from cvr_audit_info where " + 
                 "dashboard_id=" + the_dashboard.id().toString() + 
-                " order by index limit " + current.numberOfBallots() +
+                " order by index limit " + current.expectedCount() +
                 " offset " + current.startIndex());
         @SuppressWarnings("unchecked") // we know this gives us a list of numbers
         final List<Number> generic_results = (List<Number>) query.getResultList();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
@@ -19,7 +19,6 @@ import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.CriteriaUpdate;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/DatabaseResetQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/DatabaseResetQueries.java
@@ -52,7 +52,8 @@ public final class DatabaseResetQueries {
         "county_contest_vote_total", "county_contest_comparison_audit", 
         "county_contest_result", "cvr_contest_info", 
         "driving_contest", "contest", "cvr_audit_info", "cast_vote_record", 
-        "uploaded_file", "dos_dashboard", "county_dashboard"
+        "uploaded_file", "dos_dashboard", 
+        "round", "audit_board", "county_dashboard"
     };
     
     for (final String t : tables) {

--- a/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
+++ b/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
@@ -34,6 +34,7 @@ us.freeandfair.corla.endpoint.ReportBallotsToAudit
 us.freeandfair.corla.endpoint.RiskLimitForComparisonAudits
 us.freeandfair.corla.endpoint.Root
 us.freeandfair.corla.endpoint.SelectContestsForAudit
+us.freeandfair.corla.endpoint.StartAuditRound
 us.freeandfair.corla.endpoint.Unauthenticate
 us.freeandfair.corla.endpoint.UploadFile
 us.freeandfair.corla.endpoint.UploadRandomSeed

--- a/test/smoketest/main.py
+++ b/test/smoketest/main.py
@@ -420,14 +420,6 @@ def county_setup(ac, county_id):
     county_s = requests.Session()
     county_login(ac, county_s, county_id)
 
-    r = test_endpoint_json(ac, county_s, "/audit-board",
-                           [{"first_name": "Mary",
-                             "last_name": "Doe",
-                             "political_party": "Democrat"},
-                            {"first_name": "John",
-                             "last_name": "Doe",
-                             "political_party": "Republican"}])
-
     upload_files(ac, county_s)
     # Replace that with this later - or make test_endpoint_file method?
     # r = test_endpoint_post(base, county_s1, "/upload-ballot-manifest", ...)
@@ -493,6 +485,14 @@ def county_audit(ac, county_id):
     county_s = requests.Session()
     county_login(ac, county_s, county_id)
 
+    r = test_endpoint_json(ac, county_s, "/audit-board-sign-in",
+                           [{"first_name": "Mary",
+                             "last_name": "Doe",
+                             "political_party": "Democrat"},
+                            {"first_name": "John",
+                             "last_name": "Doe",
+                             "political_party": "Republican"}])
+
     # Print this tool's notion of what should be audited, based on seed etc.
     # for auditing the audit.
     # TODO or FIXME - doesn't yet match "ballots_to_audit" from the dashboard
@@ -516,6 +516,16 @@ def county_audit(ac, county_id):
     for i in range(len(selected)):
         if i % 10 == 0:
             r = test_endpoint_get(ac, ac.state_s, "/dos-dashboard", show=False)
+            
+        if i % 40 == 0:
+            r = test_endpoint_json(ac, county_s, "/audit-board-sign-out", {});
+            r = test_endpoint_json(ac, county_s, "/audit-board-sign-in",
+                           [{"first_name": "Mary",
+                             "last_name": "Doe",
+                             "political_party": "Democrat"},
+                            {"first_name": "John",
+                             "last_name": "Doe",
+                             "political_party": "Republican"}])
 
         r = test_endpoint_get(ac, county_s, "/cvr/id/%d" % selected[i], show=False)
         acvr = r.json()
@@ -560,7 +570,7 @@ def county_audit(ac, county_id):
 
     r = test_endpoint_get(ac, ac.state_s, "/dos-dashboard")
 
-    r = test_endpoint_json(ac, county_s, "/intermediate-audit-report", {})
+#    r = test_endpoint_json(ac, county_s, "/intermediate-audit-report", {})
     r = test_endpoint_json(ac, county_s, "/audit-report", {})
 
 def dos_wrapup(ac):

--- a/test/smoketest/main.py
+++ b/test/smoketest/main.py
@@ -517,7 +517,7 @@ def county_audit(ac, county_id):
         if i % 10 == 0:
             r = test_endpoint_get(ac, ac.state_s, "/dos-dashboard", show=False)
             
-        if i % 40 == 0:
+        if i % 50 == 5:
             r = test_endpoint_json(ac, county_s, "/audit-board-sign-out", {});
             r = test_endpoint_json(ac, county_s, "/audit-board-sign-in",
                            [{"first_name": "Mary",

--- a/test/smoketest/smoketest.bash
+++ b/test/smoketest/smoketest.bash
@@ -34,7 +34,7 @@ pkill -f java.-jar.target/colorado_rla || true
 dropdb corla || true
 createdb -O corla corla
 
-mkdir -p tarket
+mkdir -p target
 mvn package > target/mvn.stdout
 
 # Surprising how kludgey this seems to be https://stackoverflow.com/a/45657043/507544


### PR DESCRIPTION
This branch implements the concept of rounds on the server side. It also modifies the `main.py` test script to properly sign in and out of audit boards at reasonable intervals, and not to do both an intermediate audit report and a final one at the end; putting an intermediate audit report in the middle somewhere might make sense instead of explicitly signing out, as intermediate audit report signs out the current audit board too. 