### PR TITLE
Adding County IDs to Contests

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
@@ -36,7 +36,6 @@ import us.freeandfair.corla.model.Contest;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyContestResult;
 import us.freeandfair.corla.persistence.Persistence;
-import us.freeandfair.corla.query.ContestQueries;
 import us.freeandfair.corla.query.CountyContestResultQueries;
 
 /**
@@ -238,8 +237,9 @@ public class DominionCVRExportParser implements CVRExportParser {
       // now that we have all the choices, we can create a Contest object for 
       // this contest (note the empty contest description at the moment, below, 
       // as that's not in the CVR files and may not actually be used)
-      final Contest c = ContestQueries.matching(new Contest(cn, "", choices, 
-                                                            the_votes_allowed.get(cn)));
+      final Contest c = new Contest(cn, my_county.id(), "", choices, 
+                                    the_votes_allowed.get(cn));
+      Persistence.saveOrUpdate(c);
       final CountyContestResult r = 
           CountyContestResultQueries.matching(my_county, c);
       my_contests.add(c);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Contest.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Contest.java
@@ -35,8 +35,6 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
 
-import org.hibernate.annotations.Immutable;
-
 import us.freeandfair.corla.persistence.PersistentEntity;
 
 /**
@@ -47,14 +45,13 @@ import us.freeandfair.corla.persistence.PersistentEntity;
  * @version 0.0.1
  */
 @Entity
-@Immutable // this is a Hibernate-specific annotation, but there is no JPA alternative
 @Cacheable(true)
 @Table(name = "contest",
        uniqueConstraints = {
-           @UniqueConstraint(columnNames = {"name", "description", "votes_allowed"}) },
+           @UniqueConstraint(columnNames = {"name", "county_id", "description", "votes_allowed"}) },
        indexes = { @Index(name = "idx_contest_name", columnList = "name"),
-                   @Index(name = "idx_contest_name_description_votes_allowed", 
-                          columnList = "name, description, votes_allowed") })
+                   @Index(name = "idx_contest_name_county_description_votes_allowed", 
+                          columnList = "name, county_id, description, votes_allowed") })
 //this class has many fields that would normally be declared final, but
 //cannot be for compatibility with Hibernate and JPA.
 @SuppressWarnings("PMD.ImmutableField")
@@ -84,6 +81,12 @@ public class Contest implements PersistentEntity, Serializable {
   @Column(name = "name", updatable = false, nullable = false)
   private String my_name;
 
+  /**
+   * The contest county.
+   */
+  @Column(name = "county_id", updatable = false, nullable = false)
+  private Long my_county_id;
+  
   /**
    * The contest description.
    */
@@ -118,6 +121,7 @@ public class Contest implements PersistentEntity, Serializable {
    * Constructs a contest with the specified parameters.
    * 
    * @param the_name The contest name.
+   * @param the_county_id The county ID for this contest.
    * @param the_description The contest description.
    * @param the_choices The set of contest choices.
    * @param the_votes_allowed The maximum number of votes that can
@@ -125,10 +129,12 @@ public class Contest implements PersistentEntity, Serializable {
    */
   //@ requires 1 <= the_votes_allowed;
   //@ requires the_votes_allowed <= the_choices.size();
-  public Contest(final String the_name, final String the_description, 
-                 final List<Choice> the_choices, final int the_votes_allowed)  {
+  public Contest(final String the_name, final Long the_county_id, 
+                 final String the_description, final List<Choice> the_choices, 
+                 final int the_votes_allowed)  {
     super();
     my_name = the_name;
+    my_county_id = the_county_id;
     my_description = the_description;
     my_choices.addAll(the_choices);
     my_votes_allowed = the_votes_allowed;
@@ -170,6 +176,13 @@ public class Contest implements PersistentEntity, Serializable {
    */
   public String description() {
     return my_description;
+  }
+  
+  /**
+   * @return the county ID.
+   */
+  public Long countyID() {
+    return my_county_id;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/ContestQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/ContestQueries.java
@@ -43,57 +43,7 @@ public final class ContestQueries {
    */
   private ContestQueries() {
     // do nothing
-  }
-  
-  /**
-   * Obtain a persistent Contest object equivalent to the specified Contest
-   * object. If there is not already such a persistent Contest object,
-   * one is created and returned.
-   *
-   * @param the_contest The contest object to match.
-   * @return the matched contest object, if one exists.
-   */
-  // we are checking to see if exactly one result is in a list, and
-  // PMD doesn't like it
-  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
-  public static Contest matching(final Contest the_contest) {
-    Contest result = null;
-    
-    try {
-      final Session s = Persistence.currentSession();
-      final CriteriaBuilder cb = s.getCriteriaBuilder();
-      final CriteriaQuery<Contest> cq = cb.createQuery(Contest.class);
-      final Root<Contest> root = cq.from(Contest.class);
-      final List<Predicate> conjuncts = new ArrayList<>();
-      conjuncts.add(cb.equal(root.get("my_name"), the_contest.name()));
-      conjuncts.add(cb.equal(root.get("my_description"), the_contest.description()));
-      conjuncts.add(cb.equal(root.get("my_votes_allowed"), the_contest.votesAllowed()));
-      cq.select(root).where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
-      final TypedQuery<Contest> query = s.createQuery(cq);
-      final List<Contest> query_results = query.getResultList();
-      // if there's exactly one result, return that
-      if (query_results.size() == 1) {
-        result = query_results.get(0);
-      } else if (query_results.isEmpty()) {
-        // we need to persist a new object
-        Persistence.saveOrUpdate(the_contest);
-        result = the_contest;
-      } else {
-        Main.LOGGER.error("multiple matching contests found");
-        throw new PersistenceException("multiple matching contests found for " + 
-                                       the_contest);
-      }
-    } catch (final PersistenceException e) {
-      Main.LOGGER.error("could not query database for contest");
-    }
-    if (result == null) {
-      Main.LOGGER.debug("found no contest matching + " + the_contest);
-    } else {
-      Main.LOGGER.debug("found contest " + result);
-    }
-    return result;
-  }
-  
+  }  
   
   /**
    * Gets contests that are in the specified set of counties.


### PR DESCRIPTION
In order to distinguish contests from different counties with the same name, this branch adds county IDs to contests. The effect on the audits we actually do now is nil, since they were all within the county anyway and not spanning counties with the same contest. This also gives the DoS dashboard enough information, when it retrieves `contest` objects, to show what counties they are in even if they have the same name.