### PR TITLE
Invoke the Reset Hook

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -388,6 +388,7 @@ public abstract class AbstractEndpoint implements Endpoint {
   @SuppressWarnings("PMD.ConfusingTernary")
   @Override
   public void before(final Request the_request, final Response the_response) {
+    reset();
     my_log_entries.set(new ArrayList<LogEntry>());
     Main.LOGGER.info("endpoint " + endpointName() + " hit by " + the_request.host());
     // Start a transaction, if the database is functioning; otherwise abort


### PR DESCRIPTION
I added a reset hook so that endpoints that could have more than one possible ASM action could deal with that sanely. I added a line to invoke it. Unfortunately, that line somehow got merged or rebased away and didn't make it into master; so here it is.