### PR TITLE
Extreme Upload Acceleration

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -220,7 +220,7 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
     synchronized (COUNTIES_RUNNING) {
       if (COUNTIES_RUNNING.contains(county.id())) {
         transactionFailure(the_response, 
-                           "county " + county.id() + " is already uploading CVRs, try later");
+                           "county " + county.id() + " is already importing CVRs, try later");
         // for a transaction failure, we have to halt explicitly
         halt(the_response);
       }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -153,7 +153,6 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
         // if we couldn't clean up, there's not much we can do about it
       }
       transactionFailure(the_response, "cvr import transaction failed: " + e.getMessage());
-      ufs.stop();
       // we have to halt manually because a transaction failure doesn't halt
       halt(the_response);
     } catch (final RuntimeException | IOException e) {
@@ -165,9 +164,9 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
         // if we couldn't clean up, there's not much we can do about it
       }
       badDataContents(the_response, "malformed CVR export file " + the_file.id());
+    } finally {
+      ufs.stop();
     }
-    
-    ufs.stop();
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -187,6 +187,8 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
     final int result = 
         CastVoteRecordQueries.deleteMatching(the_county_id, RecordType.UPLOADED);
     CountyContestResultQueries.deleteForCounty(the_county_id);
+    final CountyDashboard cdb = Persistence.getByID(the_county_id, CountyDashboard.class);
+    cdb.setCVRUploadTimestamp(null);
     Persistence.commitTransaction();
     Persistence.beginTransaction();
     return result;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -321,18 +321,21 @@ public class CountyDashboardRefreshResponse {
       cvr_export_filename = cvr_export.filename();
     }
     
-    // contests
+    // contests and contests under audit
     final Set<Long> contests = new HashSet<Long>();
-    for (final Contest c : ContestQueries.forCounty(county)) {
-      contests.add(c.id());
-    }
-    
-    // contests under audit
     final Map<Long, String> contests_under_audit = new HashMap<Long, String>();
-    for (final ContestToAudit cta : dosd.contestsToAudit()) {
-      if (cta.audit() == AuditType.COMPARISON && 
-          contests.contains(cta.contest().id())) {
-        contests_under_audit.put(cta.contest().id(), cta.reason().toString());
+    if (the_dashboard.cvrUploadTimestamp() != null &&
+        the_dashboard.manifestUploadTimestamp() != null) {
+      // only add contests if uploads are done
+      for (final Contest c : ContestQueries.forCounty(county)) {
+        contests.add(c.id());
+      }
+
+      for (final ContestToAudit cta : dosd.contestsToAudit()) {
+        if (cta.audit() == AuditType.COMPARISON && 
+            contests.contains(cta.contest().id())) {
+          contests_under_audit.put(cta.contest().id(), cta.reason().toString());
+        }
       }
     }
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/util/UploadedFileStreamer.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/util/UploadedFileStreamer.java
@@ -1,0 +1,118 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Aug 30, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.SQLException;
+
+import javax.persistence.PersistenceException;
+
+import us.freeandfair.corla.model.UploadedFile;
+import us.freeandfair.corla.persistence.Persistence;
+
+/**
+ * A Runnable class that provides streaming read access to an UploadedFile.
+ * 
+ * @author Daniel M. Zimmerman
+ * @version 0.0.1
+ */
+@SuppressWarnings("PMD.DoNotUseThreads")
+public class UploadedFileStreamer implements Runnable {
+  /**
+   * The uploaded file.
+   */
+  private UploadedFile my_file;
+  
+  /**
+   * The input stream from the blob.
+   */
+  private InputStream my_stream;
+  
+  /**
+   * The running flag.
+   */
+  @SuppressWarnings("PMD.AvoidUsingVolatile")
+  private volatile boolean my_running;
+  
+  /**
+   * Constructs a new streamer for the specified file.
+   * 
+   * @param the_file The file.
+   */
+  public UploadedFileStreamer(final UploadedFile the_file) {
+    my_file = the_file;
+  }
+  
+  /**
+   * The run method. This opens up a new persistence session and database
+   * transaction, and sets up the stream for reading. This method should 
+   * only be called as a result of Thread.start(), in a fresh thread; any
+   * other use may have unpredictable consequences due to the persistence 
+   * subsystem's handling of threads.
+   * 
+   * @exception PersistenceException if there is a problem during the
+   * execution.
+   */
+  @Override
+  public synchronized void run() throws PersistenceException {
+    my_running = true;
+    Persistence.beginTransaction();
+    // get a session-local reference to the file
+    my_file = Persistence.getByID(my_file.id(), UploadedFile.class);
+    // get the blob stream
+    try {
+      my_stream = my_file.file().getBinaryStream();
+      notifyAll();
+    } catch (final SQLException e) {
+      throw new PersistenceException(e);
+    }
+    while (my_running) {
+      try {
+        wait();
+      } catch (final InterruptedException e) {
+        // ignored, since we don't care if we were interrupted
+      }
+    }
+    try {
+      my_stream.close();
+    } catch (final IOException e) {
+      // ignored, since we're already done with it
+    }
+    Persistence.rollbackTransaction();
+  }
+  
+  /**
+   * Stops this thread, closing the persistence session and the transaction. 
+   * The transactions is rolled back, so as to not interfere with any other 
+   * transactions, since we have already read all the data we needed.
+   */
+  public synchronized void stop() {
+    my_running = false;
+    notifyAll();
+  }
+  
+  /**
+   * @return the open binary stream. This stream can only be used once; to
+   * read the same uploaded file again, a new UploadedFileStreamer is required. 
+   */
+  public synchronized InputStream inputStream() {
+    while (my_stream == null) {
+      try {
+        wait();
+      } catch (final InterruptedException e) {
+        // ignored, since we don't care if we're interrupted
+      }
+    }
+    return my_stream;
+  }
+}


### PR DESCRIPTION
This implementation of CVR import parsing can, on my laptop at Galois, import 1,000,000 CVRs in 23 minutes. That compares to... well, the closest known time is @nealmcb's 3+ hours to run out of memory while trying, or @kiniry's 1 hr 40 minutes to import 500,000 with the older code.

Another data point: it takes my machine at home 38 minutes to import 1M CVRs on this branch, as compared with 199 minutes to do so on `master`.

The downside: it uses multiple transactions. There's code to clean up if something goes wrong, but if something goes wrong right at the end, there will be some cruft left in the database. The good part, though, is that the _state_ of the county dashboard will not reflect that CVRs have been uploaded, so when an upload is attempted again, the cruft will be cleaned out.

I think the same technique should probably be applied to ballot manifest imports as well, so I can do that before merging unless anybody has any objections. 

Closes #530 with extreme prejudice.