### PR TITLE
Import alias

### DIFF
--- a/client/karma.config.js
+++ b/client/karma.config.js
@@ -32,6 +32,11 @@ module.exports = config => {
 
             resolve: {
                 extensions: ['.ts', '.tsx', '.js', '.json'],
+
+                alias: {
+                    // Add an import alias for the project root.
+                    corla: path.resolve(__dirname, 'src'),
+                },
             },
 
             module: {

--- a/client/src/action/county/auditBoardSignIn.ts
+++ b/client/src/action/county/auditBoardSignIn.ts
@@ -1,8 +1,8 @@
-import { endpoint } from '../../config';
+import { endpoint } from 'corla/config';
 
 import createSubmitAction from '../createSubmitAction';
 
-import { format } from '../../adapter/establishBoard';
+import { format } from 'corla/adapter/establishBoard';
 
 
 const url = endpoint('audit-board-sign-in');

--- a/client/src/action/county/auditBoardSignOut.ts
+++ b/client/src/action/county/auditBoardSignOut.ts
@@ -1,4 +1,4 @@
-import { endpoint } from '../../config';
+import { endpoint } from 'corla/config';
 
 import createSubmitAction from '../createSubmitAction';
 

--- a/client/src/action/county/fetchReport.ts
+++ b/client/src/action/county/fetchReport.ts
@@ -1,4 +1,4 @@
-import { endpoint } from '../../config';
+import { endpoint } from 'corla/config';
 
 import createFileFetchAction from '../createFileFetchAction';
 

--- a/client/src/action/county/finishAudit.ts
+++ b/client/src/action/county/finishAudit.ts
@@ -1,4 +1,4 @@
-import { endpoint } from '../../config';
+import { endpoint } from 'corla/config';
 
 import createSubmitAction from '../createSubmitAction';
 

--- a/client/src/action/dos/fetchReport.ts
+++ b/client/src/action/dos/fetchReport.ts
@@ -1,4 +1,4 @@
-import { endpoint } from '../../config';
+import { endpoint } from 'corla/config';
 
 import createFileFetchAction from '../createFileFetchAction';
 

--- a/client/src/component/county/AuditBoard/SignInContainer.tsx
+++ b/client/src/component/county/AuditBoard/SignInContainer.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import counties from '../../../data/counties';
+import counties from 'corla/data/counties';
 
 import SignedInPage from './SignedInPage';
 import SignInPage from './SignInPage';
 
-import auditBoardSignedIn from '../../../selector/county/auditBoardSignedIn';
+import auditBoardSignedIn from 'corla/selector/county/auditBoardSignedIn';
 
 
 class AuditBoardSignInContainer extends React.Component<any, any> {

--- a/client/src/component/county/AuditBoard/SignInPage.tsx
+++ b/client/src/component/county/AuditBoard/SignInPage.tsx
@@ -4,9 +4,9 @@ import CountyNav from '../Nav';
 
 import SignInForm from './SignInForm';
 
-import auditBoardSignIn from '../../../action/county/auditBoardSignIn';
+import auditBoardSignIn from 'corla/action/county/auditBoardSignIn';
 
-import isValidAuditBoard from '../../../selector/county/isValidAuditBoard';
+import isValidAuditBoard from 'corla/selector/county/isValidAuditBoard';
 
 
 class AuditBoardSignInPage extends React.Component<any, any> {

--- a/client/src/component/county/AuditBoard/SignedInPage.tsx
+++ b/client/src/component/county/AuditBoard/SignedInPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import CountyNav from '../Nav';
 
-import auditBoardSignOut from '../../../action/county/auditBoardSignOut';
+import auditBoardSignOut from 'corla/action/county/auditBoardSignOut';
 
 
 const SignedInPage = ({ auditBoard, countyName }: any) => {

--- a/client/src/component/county/audit/CountyAuditContainer.tsx
+++ b/client/src/component/county/audit/CountyAuditContainer.tsx
@@ -5,12 +5,12 @@ import { Redirect } from 'react-router-dom';
 import CountyAuditPage from './CountyAuditPage';
 import EndOfRoundPageContainer from './EndOfRoundPageContainer';
 
-import notice from '../../../notice';
+import notice from 'corla/notice';
 
-import allRoundsComplete from '../../../selector/county/allRoundsComplete';
-import auditComplete from '../../../selector/county/auditComplete';
-import canAudit from '../../../selector/county/canAudit';
-import roundInProgress from '../../../selector/county/roundInProgress';
+import allRoundsComplete from 'corla/selector/county/allRoundsComplete';
+import auditComplete from 'corla/selector/county/auditComplete';
+import canAudit from 'corla/selector/county/canAudit';
+import roundInProgress from 'corla/selector/county/roundInProgress';
 
 
 class CountyAuditContainer extends React.Component<any, any> {

--- a/client/src/component/county/audit/EndOfRoundFormContainer.tsx
+++ b/client/src/component/county/audit/EndOfRoundFormContainer.tsx
@@ -3,9 +3,9 @@ import { connect } from 'react-redux';
 
 import EndOfRoundForm from './EndOfRoundForm';
 
-import roundSignOff from '../../../action/roundSignOff';
+import roundSignOff from 'corla/action/roundSignOff';
 
-import countyInfo from '../../../selector/county/countyInfo';
+import countyInfo from 'corla/selector/county/countyInfo';
 
 
 class EndOfRoundFormContainer extends React.Component<any, any> {

--- a/client/src/component/county/audit/EndOfRoundPage.tsx
+++ b/client/src/component/county/audit/EndOfRoundPage.tsx
@@ -4,7 +4,7 @@ import CountyNav from '../Nav';
 
 import EndOfRoundFormContainer from './EndOfRoundFormContainer';
 
-import finishAudit from '../../../action/county/finishAudit';
+import finishAudit from 'corla/action/county/finishAudit';
 
 
 const PreviousRoundSignedOff = (props: any) => {

--- a/client/src/component/county/audit/EndOfRoundPageContainer.tsx
+++ b/client/src/component/county/audit/EndOfRoundPageContainer.tsx
@@ -4,9 +4,9 @@ import { connect } from 'react-redux';
 import EndOfLastRoundPage from './EndOfLastRoundPage';
 import EndOfRoundPage from './EndOfRoundPage';
 
-import allRoundsComplete from '../../../selector/county/allRoundsComplete';
-import countyInfo from '../../../selector/county/countyInfo';
-import previousRound from '../../../selector/county/previousRound';
+import allRoundsComplete from 'corla/selector/county/allRoundsComplete';
+import countyInfo from 'corla/selector/county/countyInfo';
+import previousRound from 'corla/selector/county/previousRound';
 
 
 function signedOff(round: any): boolean {

--- a/client/src/component/county/audit/wizard/BallotAuditStage.tsx
+++ b/client/src/component/county/audit/wizard/BallotAuditStage.tsx
@@ -6,8 +6,8 @@ import { Checkbox, EditableText, MenuDivider, Radio, RadioGroup } from '@bluepri
 
 import BackButton from './BackButton';
 
-import ballotNotFound from '../../../../action/ballotNotFound';
-import countyFetchCvr from '../../../../action/countyFetchCvr';
+import ballotNotFound from 'corla/action/ballotNotFound';
+import countyFetchCvr from 'corla/action/countyFetchCvr';
 
 
 const BallotNotFoundForm = ({ ballotNotFound, currentBallot }: any) => {

--- a/client/src/component/county/audit/wizard/BallotAuditStageContainer.tsx
+++ b/client/src/component/county/audit/wizard/BallotAuditStageContainer.tsx
@@ -3,11 +3,11 @@ import { connect } from 'react-redux';
 
 import BallotAuditStage from './BallotAuditStage';
 
-import action from '../../../../action';
+import action from 'corla/action';
 
-import ballotNotFound from '../../../../action/ballotNotFound';
+import ballotNotFound from 'corla/action/ballotNotFound';
 
-import currentBallotNumber from '../../../../selector/county/currentBallotNumber';
+import currentBallotNumber from 'corla/selector/county/currentBallotNumber';
 
 
 class BallotAuditStageContainer extends React.Component<any, any> {

--- a/client/src/component/county/audit/wizard/BallotListStageContainer.tsx
+++ b/client/src/component/county/audit/wizard/BallotListStageContainer.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import BallotListStage from './BallotListStage';
 
-import countyInfo from '../../../../selector/county/countyInfo';
+import countyInfo from 'corla/selector/county/countyInfo';
 
 
 class BallotListStageContainer extends React.Component<any, any> {

--- a/client/src/component/county/audit/wizard/ReviewStageContainer.tsx
+++ b/client/src/component/county/audit/wizard/ReviewStageContainer.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import ReviewStage from './ReviewStage';
 
-import uploadAcvr from '../../../../action/uploadAcvr';
+import uploadAcvr from 'corla/action/uploadAcvr';
 
 
 class ReviewStageContainer extends React.Component<any, any> {

--- a/client/src/component/county/home/BallotManifestUploadFormContainer.tsx
+++ b/client/src/component/county/home/BallotManifestUploadFormContainer.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import BallotManifestUploadForm from './BallotManifestUploadForm';
 
-import uploadBallotManifest from '../../../action/uploadBallotManifest';
+import uploadBallotManifest from 'corla/action/uploadBallotManifest';
 
 
 const UploadedBallotManifest = ({ filename, hash, enableReupload }: any) => (

--- a/client/src/component/county/home/CVRExportUploadFormContainer.tsx
+++ b/client/src/component/county/home/CVRExportUploadFormContainer.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import CVRExportUploadForm from './CVRExportUploadForm';
 
-import uploadCvrExport from '../../../action/uploadCvrExport';
+import uploadCvrExport from 'corla/action/uploadCvrExport';
 
 
 const UploadedCvrExport = ({ enableReupload, filename, hash }: any) => (

--- a/client/src/component/county/home/CountyHomeContainer.tsx
+++ b/client/src/component/county/home/CountyHomeContainer.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import counties from '../../../data/counties';
+import counties from 'corla/data/counties';
 
 import CountyHomePage from './CountyHomePage';
 
-import finishAudit from '../../../action/county/finishAudit';
+import finishAudit from 'corla/action/county/finishAudit';
 
-import allRoundsComplete from '../../../selector/county/allRoundsComplete';
-import auditBoardSignedIn from '../../../selector/county/auditBoardSignedIn';
-import auditComplete from '../../../selector/county/auditComplete';
-import canAudit from '../../../selector/county/canAudit';
-import canRenderReport from '../../../selector/county/canRenderReport';
-import canSignIn from '../../../selector/county/canSignIn';
+import allRoundsComplete from 'corla/selector/county/allRoundsComplete';
+import auditBoardSignedIn from 'corla/selector/county/auditBoardSignedIn';
+import auditComplete from 'corla/selector/county/auditComplete';
+import canAudit from 'corla/selector/county/canAudit';
+import canRenderReport from 'corla/selector/county/canRenderReport';
+import canSignIn from 'corla/selector/county/canSignIn';
 
 
 class CountyHomeContainer extends React.Component<any, any> {

--- a/client/src/component/county/home/CountyHomePage.tsx
+++ b/client/src/component/county/home/CountyHomePage.tsx
@@ -7,7 +7,7 @@ import CountyNav from '../Nav';
 
 import FileUploadContainer from './FileUploadContainer';
 
-import fetchReport from '../../../action/county/fetchReport';
+import fetchReport from 'corla/action/county/fetchReport';
 
 
 const AuditBoardInfo = ({ signedIn }: any) => {

--- a/client/src/component/login/LoginFormContainer.tsx
+++ b/client/src/component/login/LoginFormContainer.tsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 
 import LoginForm, { FormFields } from './LoginForm';
 
-import countyLogin from '../../action/countyLogin';
-import dosLogin from '../../action/dosLogin';
+import countyLogin from 'corla/action/countyLogin';
+import dosLogin from 'corla/action/dosLogin';
 
 
 const submit = ({ dashboard, username, password }: any) => {

--- a/client/src/component/login/next/PasswordForm.tsx
+++ b/client/src/component/login/next/PasswordForm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import login1F from '../../../action/login1F';
+import login1F from 'corla/action/login1F';
 
 
 function isFormValid(form: any): boolean {

--- a/client/src/component/login/next/SecondFactorForm.tsx
+++ b/client/src/component/login/next/SecondFactorForm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import login2F from '../../../action/login2F';
+import login2F from 'corla/action/login2F';
 
 
 function isFormValid(form: any): boolean {

--- a/client/src/component/sos/DOSDashboard/ContestUpdates.tsx
+++ b/client/src/component/sos/DOSDashboard/ContestUpdates.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 
 import { Tooltip } from '@blueprintjs/core';
 
-import counties from '../../../data/counties';
+import counties from 'corla/data/counties';
 
 
 const RemainingToAuditHeader = () => {

--- a/client/src/component/sos/DOSDashboard/CountyUpdates.tsx
+++ b/client/src/component/sos/DOSDashboard/CountyUpdates.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 
 import { Tooltip } from '@blueprintjs/core';
 
-import counties from '../../../data/counties';
+import counties from 'corla/data/counties';
 
 
 function formatStatus(asmState: any) {

--- a/client/src/component/sos/DOSDashboard/Main.tsx
+++ b/client/src/component/sos/DOSDashboard/Main.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import RoundContainer from './RoundContainer';
 
-import fetchReport from '../../../action/dos/fetchReport';
+import fetchReport from 'corla/action/dos/fetchReport';
 
 
 const RiskLimitInfo = ({ riskLimit }: any) => {

--- a/client/src/component/sos/DOSDashboard/MainContainer.tsx
+++ b/client/src/component/sos/DOSDashboard/MainContainer.tsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 
 import Main from './Main';
 
-import auditStarted from '../../../selector/dos/auditStarted';
-import canRenderReport from '../../../selector/dos/canRenderReport';
+import auditStarted from 'corla/selector/dos/auditStarted';
+import canRenderReport from 'corla/selector/dos/canRenderReport';
 
 
 class MainContainer extends React.Component<any, any> {

--- a/client/src/component/sos/DOSDashboard/Round/Control.tsx
+++ b/client/src/component/sos/DOSDashboard/Round/Control.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import startNextRound from '../../../../action/dosStartNextRound';
+import startNextRound from 'corla/action/dosStartNextRound';
 
 
 const Control = (props: any) => {

--- a/client/src/component/sos/DOSDashboard/RoundContainer.tsx
+++ b/client/src/component/sos/DOSDashboard/RoundContainer.tsx
@@ -5,10 +5,10 @@ import { connect } from 'react-redux';
 import Control from './Round/Control';
 import Status from './Round/Status';
 
-import activeCounties from '../../../selector/dos/activeCounties';
-import auditStarted from '../../../selector/dos/auditStarted';
-import canStartNextRound from '../../../selector/dos/canStartNextRound';
-import currentRound from '../../../selector/dos/currentRound';
+import activeCounties from 'corla/selector/dos/activeCounties';
+import auditStarted from 'corla/selector/dos/auditStarted';
+import canStartNextRound from 'corla/selector/dos/canStartNextRound';
+import currentRound from 'corla/selector/dos/currentRound';
 
 
 class RoundContainer extends React.Component<any, any> {

--- a/client/src/component/sos/audit/AuditContainer.tsx
+++ b/client/src/component/sos/audit/AuditContainer.tsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 
 import AuditPage from './AuditPage';
 
-import setRiskLimit from '../../../action/setRiskLimit';
+import setRiskLimit from 'corla/action/setRiskLimit';
 
 
 class AuditContainer extends React.Component<any, any> {

--- a/client/src/component/sos/audit/AuditReviewContainer.tsx
+++ b/client/src/component/sos/audit/AuditReviewContainer.tsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 
 import AuditReviewPage from './AuditReviewPage';
 
-import publishBallotsToAudit from '../../../action/publishBallotsToAudit';
+import publishBallotsToAudit from 'corla/action/publishBallotsToAudit';
 
 
 class AuditBallotListContainer extends React.Component<any, any> {

--- a/client/src/component/sos/audit/AuditSeedContainer.tsx
+++ b/client/src/component/sos/audit/AuditSeedContainer.tsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 
 import AuditSeedPage from './AuditSeedPage';
 
-import uploadRandomSeed from '../../../action/uploadRandomSeed';
+import uploadRandomSeed from 'corla/action/uploadRandomSeed';
 
 
 class AuditSeedContainer extends React.Component<any, any> {

--- a/client/src/component/sos/audit/SelectContestsPageContainer.tsx
+++ b/client/src/component/sos/audit/SelectContestsPageContainer.tsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 
 import SelectContestsPage from './SelectContestsPage';
 
-import selectContestsForAudit from '../../../action/selectContestsForAudit';
+import selectContestsForAudit from 'corla/action/selectContestsForAudit';
 
 
 class SelectContestsPageContainer extends React.Component<any, any> {

--- a/client/src/component/sos/contest/ContestDetailContainer.tsx
+++ b/client/src/component/sos/contest/ContestDetailContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import dosFetchContests from '../../../action/dosFetchContests';
+import dosFetchContests from 'corla/action/dosFetchContests';
 
 import ContestDetailPage from './ContestDetailPage';
 

--- a/client/src/component/sos/county/CountyDetailContainer.tsx
+++ b/client/src/component/sos/county/CountyDetailContainer.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import counties from '../../../data/counties';
+import counties from 'corla/data/counties';
 
-import dosDashboardRefresh from '../../../action/dosDashboardRefresh';
+import dosDashboardRefresh from 'corla/action/dosDashboardRefresh';
 
 import CountyDetailPage from './CountyDetailPage';
 

--- a/client/src/component/sos/county/CountyOverviewContainer.tsx
+++ b/client/src/component/sos/county/CountyOverviewContainer.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import * as _ from 'lodash';
 
-import counties from '../../../data/counties';
+import counties from 'corla/data/counties';
 
 import CountyOverviewPage from './CountyOverviewPage';
 

--- a/client/src/selector/county/countyInfo.ts
+++ b/client/src/selector/county/countyInfo.ts
@@ -1,4 +1,4 @@
-import counties from '../../data/counties';
+import counties from 'corla/data/counties';
 
 
 function countyInfo(state: any) {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,5 +1,10 @@
 {
     "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "corla/*": ["./src/*"],
+        },
+
         "outDir": "./dist/",
         "sourceMap": true,
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -29,7 +29,12 @@ module.exports = {
 
     resolve: {
         // Add '.ts' and '.tsx' as resolvable extensions.
-        extensions: ['.ts', '.tsx', '.js', '.json']
+        extensions: ['.ts', '.tsx', '.js', '.json'],
+
+        alias: {
+            // Add an import alias for the project root.
+            corla: path.resolve(__dirname, 'src'),
+        },
     },
 
     plugins: [

--- a/client/webpack.config.prod.js
+++ b/client/webpack.config.prod.js
@@ -16,7 +16,12 @@ module.exports = {
     },
 
     resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json']
+        extensions: ['.ts', '.tsx', '.js', '.json'],
+
+        alias: {
+            // Add an import alias for the project root.
+            corla: path.resolve(__dirname, 'src'),
+        },
     },
 
     plugins: [


### PR DESCRIPTION
This PR allows the client code to use a `corla` module path prefix which aliases the project root, removing the need for deep relative imports.