### PR TITLE
CVR and CVRToAudit Query Optimization

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -100,6 +100,40 @@ public final class ComparisonAuditController {
   }
   
   /**
+   * Gets all CVRs to audit in the specified round for the specified county
+   * dashboard. This returns a list in audit order.
+   * 
+   * @param the_dashboard The dashboard.
+   * @param the_round_number The round number.
+   * @return the CVRs to audit in the specified round.
+   * @exception IllegalArgumentException if the specified round doesn't exist.
+   */
+  public static List<CVRAuditInfo> cvrsToAuditInRound(final CountyDashboard the_cdb,
+                                                      final int the_round_number) {
+    if (the_round_number < 1 || the_cdb.rounds().size() < the_round_number) {
+      throw new IllegalArgumentException("invalid round specified");
+    }
+    final Round round = the_cdb.rounds().get(the_round_number - 1);
+    return CVRAuditInfoQueries.range(the_cdb, round.startAuditedPrefixLength(), 
+                                     round.expectedAuditedPrefixLength());
+  }
+  
+  /**
+   * @return the CVR IDs remaining to audit in the current round, or an empty 
+   * list if there are no CVRs remaining to audit or if no round is in progress.
+   */
+  public static List<Long> cvrIDsRemainingInCurrentRound(final CountyDashboard the_cdb) {
+    List<Long> result = new ArrayList<Long>();
+    final Round round = the_cdb.currentRound();
+    if (round != null) {
+      result = 
+          CVRAuditInfoQueries.unauditedCVRIDsInRange(the_cdb, the_cdb.auditedPrefixLength(),
+                                                     round.expectedAuditedPrefixLength());
+    }
+    return result;
+  }
+  
+  /**
    * Compute the ballot (cards) for audit, for a particular county dashboard and 
    * start index. This returns the specified number of cards, with or without 
    * duplicates (as requested).

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -114,8 +114,8 @@ public final class ComparisonAuditController {
       throw new IllegalArgumentException("invalid round specified");
     }
     final Round round = the_cdb.rounds().get(the_round_number - 1);
-    return CVRAuditInfoQueries.range(the_cdb, round.startAuditedPrefixLength(), 
-                                     round.expectedAuditedPrefixLength());
+    return CVRAuditInfoQueries.rangeUnique(the_cdb, round.startAuditedPrefixLength(), 
+                                           round.expectedAuditedPrefixLength());
   }
   
   /**
@@ -664,10 +664,13 @@ public final class ComparisonAuditController {
    */
   private static void 
       updateCVRUnderAudit(final CountyDashboard the_cdb) {
-    final List<CVRAuditInfo> cvr_audit_info = the_cdb.cvrAuditInfo();
+    final List<CVRAuditInfo> cvr_audit_info = 
+        CVRAuditInfoQueries.range(the_cdb, 
+                                  the_cdb.auditedPrefixLength(),
+                                  the_cdb.currentRound().
+                                  expectedAuditedPrefixLength());
     int index = the_cdb.auditedPrefixLength();
-    while (index < cvr_audit_info.size()) {
-      final CVRAuditInfo cai = cvr_audit_info.get(index);
+    for (final CVRAuditInfo cai : cvr_audit_info) {
       if (cai.acvr() == null) {
         break;
       } else {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -104,10 +104,10 @@ public final class ComparisonAuditController {
   
   /**
    * Gets all CVRs to audit in the specified round for the specified county
-   * dashboard. This returns a list in audit order.
+   * dashboard. This returns a list in audit random sequence order.
    * 
    * @param the_dashboard The dashboard.
-   * @param the_round_number The round number.
+   * @param the_round_number The round number (indexed from 1).
    * @return the CVRs to audit in the specified round.
    * @exception IllegalArgumentException if the specified round doesn't exist.
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -15,6 +15,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -90,10 +91,12 @@ public final class ComparisonAuditController {
                                         minimum, maximum);
     final List<Integer> list_of_cvrs_to_audit = 
         prng.getRandomNumbers(the_min_index, the_max_index);
+    final Map<Integer, CastVoteRecord> matching_cvrs = 
+        CastVoteRecordQueries.get(the_cdb.id(), RecordType.UPLOADED, list_of_cvrs_to_audit);
     final List<CastVoteRecord> result = new ArrayList<>();
     
     for (final int index : list_of_cvrs_to_audit) {
-      result.add(CastVoteRecordQueries.get(the_cdb.id(), RecordType.UPLOADED, index));
+      result.add(matching_cvrs.get(index));
     }
     
     return result;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -26,6 +26,7 @@ import us.freeandfair.corla.asm.ASMState;
 import us.freeandfair.corla.asm.ASMUtilities;
 import us.freeandfair.corla.asm.AuditBoardDashboardASM;
 import us.freeandfair.corla.asm.CountyDashboardASM;
+import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.model.AuditBoard;
 import us.freeandfair.corla.model.Contest;
 import us.freeandfair.corla.model.ContestToAudit;
@@ -385,8 +386,9 @@ public class CountyDashboardRefreshResponse {
                                               the_dashboard.ballotsAudited(),
                                               the_dashboard.discrepancies(),
                                               the_dashboard.disagreements(),
-                                              the_dashboard.
-                                                  cvrsRemainingToAuditInCurrentRound(),
+                                              ComparisonAuditController.
+                                                  cvrIDsRemainingInCurrentRound
+                                                  (the_dashboard),
                                               the_dashboard.cvrUnderAudit(),
                                               the_dashboard.auditedPrefixLength(),
                                               the_dashboard.rounds(),

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
@@ -50,15 +50,15 @@ import us.freeandfair.corla.persistence.PersistentEntity;
  */
 @Entity
 @Immutable // this is a Hibernate-specific annotation, but there is no JPA alternative
-@Cacheable(false) // TODO: evaluate whether this should be cacheable
+@Cacheable(false) 
 @Table(name = "cast_vote_record",
        indexes = { @Index(name = "idx_cvr_county_type", columnList = "county_id, record_type"),
                    @Index(name = "idx_cvr_county_cvr_number", 
                           columnList = "county_id, cvr_number"),
                    @Index(name = "idx_cvr_county_cvr_number_type", 
-                          columnList = "county_id, sequence_number, record_type"),
-                   @Index(name = "idx_cvr_county_sequence_number_type", 
                           columnList = "county_id, cvr_number, record_type"),
+                   @Index(name = "idx_cvr_county_sequence_number_type", 
+                          columnList = "county_id, sequence_number, record_type"),
                    @Index(name = "idx_cvr_county_imprinted_id_type",
                           columnList = "county_id, imprinted_id, record_type")})
 // this class has many fields that would normally be declared final, but

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
@@ -21,6 +21,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
 
 import org.hibernate.Session;
 
@@ -38,6 +39,26 @@ import us.freeandfair.corla.persistence.Persistence;
  * @version 0.0.1
  */
 public final class CVRAuditInfoQueries {
+  /**
+   * The "my_dashboard" string.  
+   */
+  private static final String MY_DASHBOARD = "my_dashboard";
+  
+  /**
+   * The "my_index" string.
+   */
+  private static final String MY_INDEX = "my_index";
+  
+  /**
+   * The "my_cvr" string.
+   */
+  private static final String MY_CVR = "my_cvr";
+  
+  /**
+   * The "range" string.
+   */
+  private static final String RANGE = ", range[";
+  
   /**
    * Private constructor to prevent instantiation.
    */
@@ -63,19 +84,140 @@ public final class CVRAuditInfoQueries {
       final CriteriaQuery<CVRAuditInfo> cq = cb.createQuery(CVRAuditInfo.class);
       final Root<CVRAuditInfo> root = cq.from(CVRAuditInfo.class);
       final List<Predicate> conjuncts = new ArrayList<>();
-      conjuncts.add(cb.equal(root.get("my_dashboard"), the_dashboard));
-      conjuncts.add(cb.equal(root.get("my_cvr"), the_cvr));
+      conjuncts.add(cb.equal(root.get(MY_DASHBOARD), the_dashboard));
+      conjuncts.add(cb.equal(root.get(MY_CVR), the_cvr));
       cq.select(root).where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
       final TypedQuery<CVRAuditInfo> query = s.createQuery(cq);
       result = query.getResultList();
     } catch (final PersistenceException e) {
       Main.LOGGER.error("could not query database for cvr audit info");
     }
-    if (result == null) {
+    if (result == null || result.isEmpty()) {
       Main.LOGGER.debug("found no cvr audit infos matching county " +
                         the_dashboard.id() + ", CVR " + the_cvr.id());
     } else {
       Main.LOGGER.debug("found cvr audit infos " + result);
+    }
+    return result;
+  }
+  
+  /**
+   * Obtain the sublist of CVRAuditInfo objects for the specified 
+   * dashboard, starting at the specified start index (inclusive) and running 
+   * through the specified end index (exclusive), with no duplicate CVRs.
+   * Only the first occurrence of each CVR is listed.
+   * 
+   * @param the_dashboard The dashboard.
+   * @param the_start_index The start index (inclusive).
+   * @param the_end_index The end index (exclusive).
+   * @return the list of CVRAuditInfo objects, which may be empty (if the 
+   * query succeeds and no objects are found in the range) or null (if the
+   * query fails).
+   */
+  public static List<CVRAuditInfo> range(final CountyDashboard the_dashboard,
+                                         final Integer the_start_index,
+                                         final Integer the_end_index) {
+    List<CVRAuditInfo> result = null;
+    
+    try {
+      final Session s = Persistence.currentSession();
+      final CriteriaBuilder cb = s.getCriteriaBuilder();
+      final CriteriaQuery<CVRAuditInfo> cq = cb.createQuery(CVRAuditInfo.class);
+      final Subquery<Integer> sq1 = cq.subquery(Integer.class);
+      final Subquery<CVRAuditInfo> sq2 = cq.subquery(CVRAuditInfo.class);
+      final List<Predicate> conjuncts = new ArrayList<>();
+      final Root<CVRAuditInfo> root = cq.from(CVRAuditInfo.class);
+      final Root<CVRAuditInfo> subroot = sq1.from(CVRAuditInfo.class);
+      final Root<CVRAuditInfo> subroot2 = sq2.from(CVRAuditInfo.class);
+      conjuncts.add(cb.equal(subroot.get(MY_DASHBOARD), the_dashboard));
+      conjuncts.add(cb.greaterThanOrEqualTo(subroot.get(MY_INDEX), the_start_index));
+      conjuncts.add(cb.lessThan(subroot.get(MY_INDEX), the_end_index));
+      conjuncts.add(cb.equal(root.get(MY_INDEX), subroot.get(MY_INDEX)));
+      sq1.select(cb.min(subroot.get(MY_INDEX)));
+      sq1.where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
+      sq2.select(subroot2);
+      sq2.where(cb.and(cb.equal(root.get(MY_CVR),
+                                subroot2.get(MY_CVR)),
+                       cb.greaterThan(root.get(MY_INDEX),
+                                      subroot2.get(MY_INDEX))));
+      cq.select(root);
+      cq.where(cb.and(cb.equal(root.get(MY_INDEX), sq1),
+                      cb.not(cb.exists(sq2))));
+      cq.orderBy(cb.asc(root.get(MY_INDEX)));
+      final TypedQuery<CVRAuditInfo> query = s.createQuery(cq);
+      result = query.getResultList();
+    } catch (final PersistenceException e) {
+      Main.LOGGER.error("could not query database for cvr audit info range");
+    }
+    if (result == null || result.isEmpty()) {
+      Main.LOGGER.debug("found no cvr audit infos matching county " +
+                        the_dashboard.id() + RANGE + the_start_index +
+                        ", " + the_end_index + ")");
+    } else {
+      Main.LOGGER.debug("found " + result.size() + " cvr audit infos matching county " +
+                        the_dashboard.id() + RANGE + the_start_index +
+                        ", " + the_end_index + ")");
+    }
+    return result;
+  }
+  
+  /**
+   * Obtain the sublist of unaudited CVRAuditInfo objects for the specified 
+   * dashboard, starting at the specified start index (inclusive) and running 
+   * through the specified end index (exclusive), with no duplicate CVRs.
+   * Only the first occurrence of each CVR is listed.
+   * 
+   * @param the_dashboard The dashboard.
+   * @param the_start_index The start index (inclusive).
+   * @param the_end_index The end index (exclusive).
+   * @return the list of CVRAuditInfo objects, which may be empty (if the 
+   * query succeeds and no objects are found in the range) or null (if the
+   * query fails).
+   */
+  public static List<Long> unauditedCVRIDsInRange(final CountyDashboard the_dashboard,
+                                                  final Integer the_start_index,
+                                                  final Integer the_end_index) {
+    List<Long> result = null;
+    
+    try {
+      final Session s = Persistence.currentSession();
+      final CriteriaBuilder cb = s.getCriteriaBuilder();
+      final CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+      final Subquery<Integer> sq1 = cq.subquery(Integer.class);
+      final Subquery<CVRAuditInfo> sq2 = cq.subquery(CVRAuditInfo.class);
+      final List<Predicate> conjuncts = new ArrayList<>();
+      final Root<CVRAuditInfo> root = cq.from(CVRAuditInfo.class);
+      final Root<CVRAuditInfo> subroot = sq1.from(CVRAuditInfo.class);
+      final Root<CVRAuditInfo> subroot2 = sq2.from(CVRAuditInfo.class);
+      conjuncts.add(cb.equal(subroot.get(MY_DASHBOARD), the_dashboard));
+      conjuncts.add(cb.greaterThanOrEqualTo(subroot.get(MY_INDEX), the_start_index));
+      conjuncts.add(cb.lessThan(subroot.get(MY_INDEX), the_end_index));
+      conjuncts.add(cb.equal(root.get(MY_INDEX), subroot.get(MY_INDEX)));
+      conjuncts.add(cb.isNull(subroot.get("my_acvr")));
+      sq1.select(cb.min(subroot.get(MY_INDEX)));
+      sq1.where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
+      sq2.select(subroot2);
+      sq2.where(cb.and(cb.equal(root.get(MY_CVR),
+                                subroot2.get(MY_CVR)),
+                       cb.greaterThan(root.get(MY_INDEX),
+                                      subroot2.get(MY_INDEX))));
+      cq.select(root.get(MY_CVR).get("my_id"));
+      cq.where(cb.and(cb.equal(root.get(MY_INDEX), sq1),
+                      cb.not(cb.exists(sq2))));
+      cq.orderBy(cb.asc(root.get(MY_INDEX)));
+      final TypedQuery<Long> query = s.createQuery(cq);
+      result = query.getResultList();
+    } catch (final PersistenceException e) {
+      Main.LOGGER.error("could not query database for unaudited cvr range");
+    }
+    if (result == null || result.isEmpty()) {
+      Main.LOGGER.debug("found no unaudited cvrs matching county " +
+                        the_dashboard.id() + RANGE + the_start_index +
+                        ", " + the_end_index + ")");
+    } else {
+      Main.LOGGER.debug("found " + result.size() + " unaudited cvrs matching " +
+                        "county " + the_dashboard.id() + RANGE + the_start_index +
+                        ", " + the_end_index + ")");
     }
     return result;
   }
@@ -99,8 +241,8 @@ public final class CVRAuditInfoQueries {
     final CriteriaQuery<CVRAuditInfo> cq = cb.createQuery(CVRAuditInfo.class);
     final Root<CVRAuditInfo> root = cq.from(CVRAuditInfo.class);
     final List<Predicate> conjuncts = new ArrayList<>();
-    conjuncts.add(cb.equal(root.get("my_dashboard"), the_dashboard));
-    conjuncts.add(cb.equal(root.get("my_cvr"), the_cvr));
+    conjuncts.add(cb.equal(root.get(MY_DASHBOARD), the_dashboard));
+    conjuncts.add(cb.equal(root.get(MY_CVR), the_cvr));
     cq.select(root);
     cq.where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
     final TypedQuery<CVRAuditInfo> query = s.createQuery(cq);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
@@ -12,8 +12,12 @@
 package us.freeandfair.corla.query;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -242,8 +246,8 @@ public final class CastVoteRecordQueries {
   }
   
   /**
-   * Obtain the CastVoteRecord object with the specified timestamp,
-   * county, type, and sequence number. 
+   * Obtain the CastVoteRecord object with the specified county, type, 
+   * and sequence number. 
    *
    * @param the_county_id The county.
    * @param the_type The type.
@@ -283,6 +287,51 @@ public final class CastVoteRecordQueries {
                         ", type " + the_type + ", sequence " + the_sequence_number);
     } else {
       Main.LOGGER.debug("found CVR " + result);
+    }
+    
+    return result;
+  }
+  
+  /**
+   * Obtain the CastVoteRecord objects with the specified county, type, and
+   * sequence numbers.
+   * 
+   * @param the_county_id The county.
+   * @param the_type The type.
+   * @param the_sequence_numbers The sequence numbers.
+   * @return the matching CastVoteRecord objects, mapped by sequence number,
+   * an empty map if no records match, or null if the query fails.
+   */
+  public static Map<Integer, CastVoteRecord> get(final Long the_county_id,
+                                                 final RecordType the_type,
+                                                 final List<Integer> the_sequence_numbers) {
+    Map<Integer, CastVoteRecord> result = null;
+    final Set<Integer> unique_numbers = new HashSet<>(the_sequence_numbers);
+   
+    try {
+      final Session s = Persistence.currentSession();
+      final CriteriaBuilder cb = s.getCriteriaBuilder();
+      final CriteriaQuery<CastVoteRecord> cq = cb.createQuery(CastVoteRecord.class);
+      final Root<CastVoteRecord> root = cq.from(CastVoteRecord.class);
+      final List<Predicate> conjuncts = new ArrayList<>();
+      conjuncts.add(cb.equal(root.get(COUNTY_ID), the_county_id));
+      conjuncts.add(cb.equal(root.get(RECORD_TYPE), the_type));
+      conjuncts.add(root.get("my_sequence_number").in(unique_numbers));
+      cq.select(root).where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
+      final TypedQuery<CastVoteRecord> query = s.createQuery(cq);
+      final List<CastVoteRecord> query_results = query.getResultList();
+      result = new HashMap<>();
+      for (final CastVoteRecord cvr : query_results) {
+        result.put(cvr.sequenceNumber(), cvr);
+      }
+    } catch (final PersistenceException e) {
+      Main.LOGGER.error(COULD_NOT_QUERY_DATABASE);
+    }
+    if (result == null) {
+      Main.LOGGER.debug("found no CVRs for county " + the_county_id +
+                        ", type " + the_type + ", sequence " + unique_numbers);
+    } else {
+      Main.LOGGER.debug("found " + result.keySet().size() + "CVRs ");
     }
     
     return result;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
@@ -18,7 +18,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.OptionalInt;
@@ -39,7 +38,6 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.model.CVRAuditInfo;
-import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.County.NameComparator;
@@ -47,7 +45,6 @@ import us.freeandfair.corla.model.CountyContestResult;
 import us.freeandfair.corla.model.DoSDashboard;
 import us.freeandfair.corla.model.Round;
 import us.freeandfair.corla.persistence.Persistence;
-import us.freeandfair.corla.query.CVRAuditInfoQueries;
 import us.freeandfair.corla.query.CastVoteRecordQueries;
 
 /**
@@ -456,20 +453,14 @@ public class StateReport {
         cell.setCellValue("Disagreement");
 
         max_cell_number = Math.max(max_cell_number, cell_number);
-        for (final CastVoteRecord cvr : 
+        for (final CVRAuditInfo audit_info : 
              e.getValue().cvrsToAuditByRound().get(round.number())) {
-          final List<CVRAuditInfo> audit_info_list = 
-              CVRAuditInfoQueries.matching(e.getValue().dashboard(), cvr);
-          if (audit_info_list == null || audit_info_list.isEmpty()) {
-            continue;
-          }
-          final CVRAuditInfo audit_info = audit_info_list.get(0);
           row = county_sheet.createRow(row_number++);
           cell_number = 0;
           cell = row.createCell(cell_number++);
           cell.setCellType(CellType.STRING);
           cell.setCellStyle(standard_style);
-          cell.setCellValue(cvr.imprintedID());
+          cell.setCellValue(audit_info.cvr().imprintedID());
           cell = row.createCell(cell_number++);
           cell.setCellType(CellType.BOOLEAN);
           cell.setCellStyle(standard_style);


### PR DESCRIPTION
Added optimized queries for:

- the random sequence of CVRs to audit (including duplicate samples)
- the list of upcoming ballots to audit (deduplicated and in audit order)
- the list of all ballots audited in a round with all their associated information (deduplicated and in audit order)
- the list of all ballots in a range (including duplicates)

This removes the linear-number-of-query searches through the CVR table for CVRs to audit, the ballots to audit list for duplicates and already-audited ballots during dashboard refreshes (and, thus, the linear number of database queries that went along with them); the lists do obviously still have to be created in the first place when the audit round starts and rendered into JSON for county dashboard refreshes, and audit calculations are done on all ballots in the sequence as they come up - all of those are linear operations, and can't be accelerated beyond minor Java optimizations (if any are still available at this point). But, it _does_ make a constant number of database queries per round started, ballot submitted, and dashboard request, which is a _huge_ improvement.

As an example of the performance increase, I attempted to audit the 1000 ballot sample file to completion (injecting ballot not found every so often so the audit never finishes until the ballots run out) earlier today, and it took 19 minutes; after this query optimization it took 3 3/4 minutes. I ran the 10000 ballot one overnight and it didn't come close to finishing before this query optimization; now it takes about 4 hours (which is still not great, but I have some ideas about that too).

We might want to consider adding an endpoint to get the current list of ballots remaining to audit in the round (in audit order) only if/when the client needs it , rather than including it in every county dashboard refresh (it's actually not clear to me that the client ever really needs it, since it always has the _current_ ballot under audit in the dashboard refresh, as well as round counts and such). The current `/cvrs-to-audit` endpoint actually supplies enough information to be such a list (since it includes audit sequence numbers), it's just sorted in ballot identification order.

Closes #638 with extreme prejudice