### PR TITLE
Use try-with-resources on download endpoints

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
@@ -71,10 +71,9 @@ public class ACVRDownload extends AbstractEndpoint {
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
   public String endpoint(final Request the_request, final Response the_response) {
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-      final JsonWriter jw = new JsonWriter(bw);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+         JsonWriter jw = new JsonWriter(bw)) {
       jw.beginArray();
       final Stream<CastVoteRecord> matches = 
           Stream.concat(CastVoteRecordQueries.getMatching(RecordType.AUDITOR_ENTERED),

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
@@ -77,10 +77,9 @@ public class ACVRDownloadByCounty extends AbstractEndpoint {
     for (final String s : the_request.queryParams()) {
       county_set.add(Long.valueOf(s));
     }
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-      final JsonWriter jw = new JsonWriter(bw);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+         JsonWriter jw = new JsonWriter(bw)) {
       jw.beginArray();
       for (final Long county : county_set) {
         final Stream<CastVoteRecord> matches = 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
@@ -57,10 +57,9 @@ public class BallotManifestDownload extends AbstractCountyDashboardEndpoint {
    */
   @Override
   public String endpoint(final Request the_request, final Response the_response) {
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-      final JsonWriter jw = new JsonWriter(bw);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+         JsonWriter jw = new JsonWriter(bw)) {
       jw.beginArray();
       final Stream<BallotManifestInfo> bmi_stream = 
           Persistence.getAllAsStream(BallotManifestInfo.class);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
@@ -68,10 +68,9 @@ public class BallotManifestDownloadByCounty extends AbstractCountyDashboardEndpo
       if (matches == null) {
         serverError(the_response, "Error retrieving records from database");
       } else {
-        try {
-          final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-          final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-          final JsonWriter jw = new JsonWriter(bw);
+        try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+             JsonWriter jw = new JsonWriter(bw)) {
           jw.beginArray();
           for (final BallotManifestInfo bmi : matches) {
             jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(bmi)));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
@@ -71,10 +71,9 @@ public class CVRDownload extends AbstractEndpoint {
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
   public String endpoint(final Request the_request, final Response the_response) {
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-      final JsonWriter jw = new JsonWriter(bw);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+         JsonWriter jw = new JsonWriter(bw)) {
       jw.beginArray();
       final Stream<CastVoteRecord> matches = 
           CastVoteRecordQueries.getMatching(RecordType.UPLOADED);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
@@ -77,10 +77,9 @@ public class CVRDownloadByCounty extends AbstractEndpoint {
     for (final String s : the_request.queryParams()) {
       county_set.add(Long.valueOf(s));
     }
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-      final JsonWriter jw = new JsonWriter(bw);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+         JsonWriter jw = new JsonWriter(bw)) {
       jw.beginArray();
       for (final Long county : county_set) {
         final Stream<CastVoteRecord> matches = 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
@@ -77,10 +77,9 @@ public class ContestDownload extends AbstractEndpoint {
       }
     }
     final List<Contest> contest_list = ContestQueries.forCounties(county_set);
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-      final JsonWriter jw = new JsonWriter(bw);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+         JsonWriter jw = new JsonWriter(bw)) {
       jw.beginArray();
       for (final Contest contest : contest_list) {
         jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(contest)));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
@@ -83,10 +83,9 @@ public class ContestDownloadByCounty extends AbstractEndpoint {
         }
       }
       final List<Contest> contest_list = ContestQueries.forCounties(county_set);
-      try {
-        final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-        final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-        final JsonWriter jw = new JsonWriter(bw);
+      try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+           BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+           JsonWriter jw = new JsonWriter(bw)) {
         jw.beginArray();
         for (final Contest contest : contest_list) {
           jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(contest)));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyReportDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyReportDownload.java
@@ -64,9 +64,8 @@ public class CountyReportDownload extends AbstractEndpoint {
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
   public String endpoint(final Request the_request, final Response the_response) {
     final boolean pdf = "pdf".equalsIgnoreCase(the_request.queryParams("file_type"));
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedOutputStream bos = new BufferedOutputStream(os);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedOutputStream bos = new BufferedOutputStream(os)) {
       final CountyReport cr = 
           new CountyReport(Main.authentication().authenticatedCounty(the_request));
       if (pdf) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
@@ -63,9 +63,8 @@ public class StateReportDownload extends AbstractEndpoint {
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
   public String endpoint(final Request the_request, final Response the_response) {
     final boolean pdf = "pdf".equalsIgnoreCase(the_request.queryParams("file_type"));
-    try {
-      final OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-      final BufferedOutputStream bos = new BufferedOutputStream(os);
+    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+         BufferedOutputStream bos = new BufferedOutputStream(os)) {
       final StateReport cr = new StateReport();
       if (pdf) {
         the_response.type("application/pdf");


### PR DESCRIPTION
Because one instance of this was pointed out in the "security" scan, and because it's generally a good idea, I've converted all the download endpoints to use try-with-resources constructions for their streams.