### PR TITLE
Pairwise Margin Calculation Changes

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ import us.freeandfair.corla.util.Pair;
  * @author Daniel M. Zimmerman
  * @version 0.0.1
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.CyclomaticComplexity"})
+@SuppressWarnings({"PMD.GodClass", "PMD.CyclomaticComplexity", "PMD.ExcessiveImports"})
 public final class ComparisonAuditController {
   /**
    * Private constructor to prevent instantiation.
@@ -638,13 +639,14 @@ public final class ComparisonAuditController {
     
     for (final CountyContestComparisonAudit ca : the_cdb.comparisonAudits()) {
       audit_reasons.put(ca.contest(), ca.auditReason());
-      final int discrepancy = ca.computeDiscrepancy(the_cvr_under_audit, the_audit_cvr);
-      for (int i = 0; i < the_count; i++) {
-        ca.recordDiscrepancy(discrepancy);
+      final OptionalInt discrepancy = 
+          ca.computeDiscrepancy(the_cvr_under_audit, the_audit_cvr);
+      if (discrepancy.isPresent()) {
+        for (int i = 0; i < the_count; i++) {
+          ca.recordDiscrepancy(discrepancy.getAsInt());
+        }
       }
-      if (discrepancy != 0) {
-        discrepancies.add(ca.auditReason());
-      }
+      discrepancies.add(ca.auditReason());
     }
     
     for (final CVRContestInfo ci : the_audit_cvr.contestInfo()) {
@@ -687,13 +689,14 @@ public final class ComparisonAuditController {
     
     for (final CountyContestComparisonAudit ca : the_cdb.comparisonAudits()) {
       audit_reasons.put(ca.contest(), ca.auditReason());
-      final int discrepancy = ca.computeDiscrepancy(the_cvr_under_audit, the_audit_cvr);
-      for (int i = 0; i < the_count; i++) {
-        ca.removeDiscrepancy(discrepancy);
+      final OptionalInt discrepancy = 
+          ca.computeDiscrepancy(the_cvr_under_audit, the_audit_cvr);
+      if (discrepancy.isPresent()) {
+        for (int i = 0; i < the_count; i++) {
+          ca.removeDiscrepancy(discrepancy.getAsInt());
+        }
       }
-      if (discrepancy != 0) {
-        discrepancies.add(ca.auditReason());
-      }
+      discrepancies.remove(ca.auditReason());
     }
     
     for (final CVRContestInfo ci : the_audit_cvr.contestInfo()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -518,7 +518,7 @@ public class CountyDashboard implements PersistentEntity, Serializable {
       for (final CountyContestComparisonAudit ca : comparisonAudits()) {
         audit_reasons.put(ca.contest(), ca.auditReason());
         if (!discrepancies.contains(ca.auditReason()) && 
-            ca.computeDiscrepancy(cvrai.cvr(), cvrai.acvr()) != 0) {
+            ca.computeDiscrepancy(cvrai.cvr(), cvrai.acvr()).isPresent()) {
           discrepancies.add(ca.auditReason());
         }
       }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/util/Pair.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/util/Pair.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.util;
 
+import static us.freeandfair.corla.util.EqualsHashcodeHelper.*;
+
 /**
  * A pair of objects, potentially of different types.
  * 
@@ -61,5 +63,32 @@ public class Pair<A, B> {
    */
   public B second() {
     return my_second;
+  }
+  
+  /**
+   * Compares this pair with another for equivalence.
+   * 
+   * @param the_other The other pair.
+   * @return true if the two pairs are equivalent, false otherwise.
+   */
+  public boolean equals(final Object the_other) {
+    final boolean result;
+    
+    if (the_other instanceof Pair) {
+      final Pair<?, ?> other_pair = (Pair<?, ?>) the_other;
+      result = nullableEquals(other_pair.first(), first()) &&
+               nullableEquals(other_pair.second(), second());
+    } else {
+      result = false;
+    }
+    
+    return result;
+  }
+  
+  /**
+   * @return a hash code for this pair.
+   */
+  public int hashCode() {
+    return nullableHashCode(first()) + 7 * nullableHashCode(second());
   }
 }


### PR DESCRIPTION
Previously, we were calculating discrepancies by dealing with sets of winners and losers all at once; while that calculation worked, albeit being occasionally pessimistic, it is harder to have confidence in than a calculation that explicitly computes the discrepancy between each winner and loser in each contest. This introduces such a calculation.