### PR TITLE
Consistently list audited CVRs

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -184,8 +184,11 @@ public final class ComparisonAuditController {
       final List<CastVoteRecord> new_cvrs = getCVRsInAuditSequence(the_cdb, start, end);
       for (int i = 0; i < new_cvrs.size(); i++) {
         final CastVoteRecord cvr = new_cvrs.get(i);
+        if (!cvr_set.contains(cvr)) {
+          cvr.setAuditFlag(audited(the_cdb, cvr));
+        }
         if ((the_duplicates || !cvr_set.contains(cvr)) && 
-            (the_audited || !audited(the_cdb, cvr))) {
+            (the_audited || !cvr.auditFlag())) {
           cvr_to_audit_list.add(cvr);
         }
         cvr_set.add(cvr);


### PR DESCRIPTION
Previously, if you listed CVRs by round and asked for audited ones you would get them, but if you listed them by index and count and asked for audited ones you would not. Now you do.