### PR TITLE
Add the ability to download CSV of ballots to audit

### DIFF
--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -193,5 +193,10 @@
 			<artifactId>poi-ooxml</artifactId>
 			<version>3.16</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-core</artifactId>
+			<version>3.1.12</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -531,6 +531,10 @@ public final class Main {
    * server does not start.
    */
   public static void main(final String... the_args) {
+    // set headless mode - this prevents Apache POI from starting a GUI when
+    // generating Excel files
+    System.setProperty("java.awt.headless", "true");
+    
     final Properties default_properties = defaultProperties();
     Properties properties = new Properties(default_properties);
     if (the_args.length > 0) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -1,0 +1,280 @@
+/*
+ * Free & Fair Colorado RLA System
+ * 
+ * @title ColoradoRLA
+ * @created Jul 27, 2017
+ * @copyright 2017 Free & Fair
+ * @license GNU General Public License 3.0
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.endpoint;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.OptionalInt;
+
+import javax.persistence.PersistenceException;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.QuoteMode;
+import org.apache.cxf.attachment.Rfc5987Util;
+
+import spark.Request;
+import spark.Response;
+
+import us.freeandfair.corla.Main;
+import us.freeandfair.corla.controller.ComparisonAuditController;
+import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
+import us.freeandfair.corla.model.CastVoteRecord;
+import us.freeandfair.corla.model.County;
+import us.freeandfair.corla.model.CountyDashboard;
+import us.freeandfair.corla.persistence.Persistence;
+import us.freeandfair.corla.query.BallotManifestInfoQueries;
+import us.freeandfair.corla.util.SparkHelper;
+
+/**
+ * The CVR to audit download endpoint.
+ * 
+ * @author Daniel M. Zimmerman
+ * @version 0.0.1
+ */
+@SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.CyclomaticComplexity",
+    "PMD.ModifiedCyclomaticComplexity", "PMD.StdCyclomaticComplexity"})
+public class CVRToAuditDownload extends AbstractEndpoint {
+  /**
+   * The "start" parameter.
+   */
+  public static final String START = "start";
+  
+  /**
+   * The "ballot_count" parameter.
+   */
+  public static final String BALLOT_COUNT = "ballot_count";
+  
+  /**
+   * The "include duplicates" parameter.
+   */
+  public static final String INCLUDE_DUPLICATES = "include_duplicates";
+  
+  /**
+   * The "include audited" parameter.
+   */
+  public static final String INCLUDE_AUDITED = "include_audited";
+  
+  /**
+   * The "round" parameter.
+   */
+  public static final String ROUND = "round";
+  
+  /**
+   * The CSV headers for formatting the response.
+   */
+  private static final String[] CSV_HEADERS = {
+      "scanner_id", "batch_id", "record_id", "imprinted_id", "ballot_type",
+      "storage_location", "cvr_number", "audit_sequence_number", "audited"
+  };
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public EndpointType endpointType() {
+    return EndpointType.GET;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String endpointName() {
+    return "/cvr-to-audit-download";
+  }
+  
+  /**
+   * This endpoint requires any kind of authentication.
+   */
+  @Override
+  public AuthorizationType requiredAuthorization() {
+    return AuthorizationType.COUNTY;
+  }
+
+  /**
+   * Validate the request parameters. In this case, the two parameters
+   * must exist and both be non-negative integers.
+   * 
+   * @param the_request The request.
+   */
+  @Override
+  protected boolean validateParameters(final Request the_request) {
+    final String start = the_request.queryParams(START);
+    final String ballot_count = the_request.queryParams(BALLOT_COUNT);
+    final String round = the_request.queryParams(ROUND);
+    
+    boolean result = start != null && ballot_count != null ||
+                     round != null;
+    
+    if (result) {
+      try {
+        if (start != null) {
+          final int s = Integer.parseInt(start);
+          result &= s >= 0;
+          final int b = Integer.parseInt(ballot_count);
+          result &= b >= 0;
+        }
+        
+        if (round != null) {
+          final int r = Integer.parseInt(round);
+          result &= r > 0;
+        }
+      } catch (final NumberFormatException e) {
+        result = false;
+      }
+    }
+    
+    return result;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength", 
+                     "checkstyle:methodlength", "checkstyle:executablestatementcount"})
+  public String endpoint(final Request the_request, final Response the_response) {
+    try {
+      // get the request parameters
+      final String start_param = the_request.queryParams(START);
+      final String ballot_count_param = the_request.queryParams(BALLOT_COUNT);
+      final String duplicates_param = the_request.queryParams(INCLUDE_DUPLICATES);
+      final String audited_param = the_request.queryParams(INCLUDE_AUDITED);
+      final String round_param = the_request.queryParams(ROUND);
+
+      int ballot_count = 0;
+      if (ballot_count_param != null) {
+        ballot_count = Integer.parseInt(ballot_count_param);
+      }
+      int index = 0;
+      if (start_param != null) {
+        index = Integer.parseInt(start_param);
+      }
+      final boolean duplicates;
+      if (duplicates_param == null) {
+        duplicates = false;
+      } else {
+        duplicates = true;
+      }
+      final boolean audited;
+      if (audited_param == null) {
+        audited = false;
+      } else {
+        audited = true;
+      }
+      // get other things we need
+      final County county = Main.authentication().authenticatedCounty(the_request);
+      final CountyDashboard cdb = Persistence.getByID(county.id(), CountyDashboard.class);
+      final List<CastVoteRecord> cvr_to_audit_list;      
+      final List<CVRToAuditResponse> response_list = new ArrayList<>();
+      
+      // compute the round, if any
+      OptionalInt round = OptionalInt.empty(); 
+      if (round_param != null) {
+        final int round_number = Integer.parseInt(round_param);
+        if (0 < round_number && round_number <= cdb.rounds().size()) {
+          round = OptionalInt.of(round_number);
+        } else {
+          badDataContents(the_response, "cvr list requested for invalid round " + 
+                                        round_param + " for county " + cdb.id());
+        }
+      }
+      
+      if (round.isPresent()) {
+        cvr_to_audit_list = 
+            ComparisonAuditController.computeBallotOrder(cdb, round.getAsInt(), audited);
+      } else {
+        cvr_to_audit_list = 
+            ComparisonAuditController.computeBallotOrder(cdb, index, ballot_count, 
+                                                         duplicates, audited);
+      }
+     
+      for (int i = 0; i < cvr_to_audit_list.size(); i++) {
+        final CastVoteRecord cvr = cvr_to_audit_list.get(i);
+        final String location = BallotManifestInfoQueries.locationFor(cvr);
+        response_list.add(new CVRToAuditResponse(i, cvr.scannerID(), 
+                                                 cvr.batchID(), cvr.recordID(), 
+                                                 cvr.imprintedID(), 
+                                                 cvr.cvrNumber(), cvr.id(),
+                                                 cvr.ballotType(), location,
+                                                 cvr.auditFlag()));
+      }
+      response_list.sort(new BallotOrderComparator());
+      
+      // generate a CSV file from the response list
+      the_response.type("text/csv");
+      
+      // the file name should be constructed from the election type and date, and
+      // the county name and round
+      final StringBuilder sb = new StringBuilder(32);
+      sb.append("ballot-list-");
+      sb.append(county.name().toLowerCase(Locale.getDefault()).replace(" ", "_"));
+      sb.append('-');
+      if (round.isPresent()) {
+        sb.append("round-");
+        sb.append(round.getAsInt());
+      } else {
+        sb.append("start-");
+        sb.append(index);
+        sb.append("-count-");
+        sb.append(ballot_count);
+      }
+      sb.append(".csv");
+      
+      try {
+        the_response.raw().setHeader("Content-Disposition", "attachment; filename=\"" + 
+                                     Rfc5987Util.encode(sb.toString(), "UTF-8") + "\"");
+      } catch (final UnsupportedEncodingException e) {
+        serverError(the_response, "UTF-8 is unsupported (this should never happen)");
+      }
+      
+      try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+           BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"))) {
+        writeCSV(response_list, bw);
+      } catch (final IOException e) {
+        serverError(the_response, "Unable to stream response");
+      }
+    } catch (final PersistenceException e) {
+      serverError(the_response, "could not generate cvr list");
+    }
+    return my_endpoint_result.get();
+  }
+  
+  /**
+   * Writes the specified list of CVRToAuditResponse objects as CSV.
+   * 
+   * @param the_cvrs The list of objects.
+   * @param the_writer The writer to write to.
+   * @exception IOException if there is a problem writing the CSV file.
+   */
+  private void writeCSV(final List<CVRToAuditResponse> the_cvrs, final Writer the_writer) 
+      throws IOException {
+    try (CSVPrinter csvp = new CSVPrinter(the_writer, 
+                                          CSVFormat.DEFAULT.withHeader(CSV_HEADERS).
+                                          withQuoteMode(QuoteMode.NON_NUMERIC))) {
+      for (final CVRToAuditResponse cvr : the_cvrs) {
+        csvp.printRecord(cvr.scannerID(), cvr.batchID(), cvr.recordID(), cvr.imprintedID(),
+                         cvr.ballotType(), cvr.storageLocation(), cvr.cvrNumber(), 
+                         cvr.auditSequenceNumber(), cvr.audited());
+      }
+    } 
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -222,8 +222,8 @@ public class CVRToAuditDownload extends AbstractEndpoint {
       // generate a CSV file from the response list
       the_response.type("text/csv");
       
-      // the file name should be constructed from the election type and date, and
-      // the county name and round
+      // the file name should be constructed from the county name and round
+      // or start/count
       final StringBuilder sb = new StringBuilder(32);
       sb.append("ballot-list-");
       sb.append(county.name().toLowerCase(Locale.getDefault()).replace(" ", "_"));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
@@ -14,8 +14,11 @@ package us.freeandfair.corla.endpoint;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 
 import javax.persistence.PersistenceException;
+
+import org.apache.cxf.attachment.Rfc5987Util;
 
 import spark.Request;
 import spark.Response;
@@ -63,21 +66,42 @@ public class StateReportDownload extends AbstractEndpoint {
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
   public String endpoint(final Request the_request, final Response the_response) {
     final boolean pdf = "pdf".equalsIgnoreCase(the_request.queryParams("file_type"));
+    final StateReport sr = new StateReport();
+    byte[] file = new byte[0];
+    String filename = "";
+    
+    if (pdf) {
+      the_response.type("application/pdf");
+      filename = sr.filenamePDF();
+      file = sr.generatePDF();
+    } else {
+      the_response.type("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+      // the file name should be constructed from the election type and date, and
+      // the county name and round
+      filename = sr.filenameExcel();
+      try {
+        file = sr.generateExcel();
+      } catch (final IOException e) {
+        serverError(the_response, "Unable to generate Excel file");
+      }
+    }
+    
+    try {
+      the_response.raw().setHeader("Content-Disposition", "attachment; filename=\"" + 
+          Rfc5987Util.encode(filename, "UTF-8") + "\"");
+    } catch (final UnsupportedEncodingException e) {
+      serverError(the_response, "UTF-8 is unsupported (this should never happen)");
+    }
+    
     try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
          BufferedOutputStream bos = new BufferedOutputStream(os)) {
-      final StateReport cr = new StateReport();
-      if (pdf) {
-        the_response.type("application/pdf");
-        bos.write(cr.generatePDF());
-      } else {
-        the_response.type("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        bos.write(cr.generateExcel());
-      }
+      bos.write(file);
       bos.flush();
       ok(the_response);
     } catch (final IOException | PersistenceException e) {
       serverError(the_response, "Unable to stream response");
     }
+    
     return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -114,6 +114,76 @@ public class CVRToAuditResponse {
   }
   
   /**
+   * @return the audit sequence number.
+   */
+  public int auditSequenceNumber() {
+    return my_audit_sequence_number;
+  }
+  
+  /**
+   * @return the scanner ID.
+   */
+  public int scannerID() {
+    return my_scanner_id;
+  }
+  
+  /**
+   * @return the batch ID.
+   */
+  public int batchID() {
+    return my_batch_id;
+  }
+  
+  /**
+   * @return the record ID.
+   */
+  public int recordID() {
+    return my_record_id;
+  }
+  
+  /**
+   * @return the imprinted ID.
+   */
+  public String imprintedID() {
+    return my_imprinted_id;
+  }
+  
+  /**
+   * @return the CVR number.
+   */
+  public int cvrNumber() {
+    return my_cvr_number;
+  }
+  
+  /**
+   * @return the database ID.
+   */
+  public long dbID() {
+    return my_db_id;
+  }
+  
+  /**
+   * @return the ballot type.
+   */
+  public String ballotType() {
+    return my_ballot_type;
+  }
+  
+  /**
+   * @return the storage location.
+   */
+  public String storageLocation() {
+    return my_storage_location;
+  }
+  
+  /**
+   * @return the audited flag.
+   */
+  public boolean audited() {
+    return my_audited;
+  }
+  
+  /**
    * A comparator to sort CVRLocationResponse objects by scanner ID, then batch ID,
    * then record ID.
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -16,11 +16,15 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.OptionalInt;
 
@@ -647,5 +651,38 @@ public class CountyReport {
    */
   public byte[] generatePDF() {
     return new byte[0];
+  }
+  
+  /**
+   * @return the filename for the Excel version of this report.
+   */
+  public String filenameExcel() {
+    // the file name should be constructed from the county name, election
+    // type and date, and report generation time
+    final LocalDateTime election_datetime = 
+        LocalDateTime.ofInstant(my_dosdb.auditInfo().electionDate(), ZoneId.systemDefault());
+    final LocalDateTime report_datetime = 
+        LocalDateTime.ofInstant(my_timestamp, ZoneId.systemDefault()).
+        truncatedTo(ChronoUnit.SECONDS);
+    final StringBuilder sb = new StringBuilder(32);
+    
+    sb.append(my_county.name().toLowerCase(Locale.getDefault()).replace(" ", "_"));
+    sb.append('-');
+    sb.append(my_dosdb.auditInfo().electionType().
+              toLowerCase(Locale.getDefault()).replace(" ", "_"));
+    sb.append('-');
+    sb.append(DateTimeFormatter.ISO_LOCAL_DATE.format(election_datetime));
+    sb.append("-report-");
+    sb.append(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(report_datetime).replace(":", "_"));
+    sb.append(".xlsx");
+    
+    return sb.toString();
+  }
+  
+  /**
+   * @return the filename for the PDF version of this report.
+   */
+  public String filenamePDF() {
+    return filenameExcel().replaceAll(".xlsx$", ".pdf");
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
@@ -16,10 +16,14 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.OptionalInt;
@@ -545,5 +549,37 @@ public class StateReport {
    */
   public byte[] generatePDF() {
     return new byte[0];
+  }
+  
+  /**
+   * @return the filename for the Excel version of this report.
+   */
+  public String filenameExcel() {
+    // the file name should be constructed from the county name, election
+    // type and date, and report generation time
+    final LocalDateTime election_datetime = 
+        LocalDateTime.ofInstant(my_dosdb.auditInfo().electionDate(), ZoneId.systemDefault());
+    final LocalDateTime report_datetime = 
+        LocalDateTime.ofInstant(my_timestamp, ZoneId.systemDefault()).
+        truncatedTo(ChronoUnit.SECONDS);
+    final StringBuilder sb = new StringBuilder(32);
+
+    sb.append("state-");
+    sb.append(my_dosdb.auditInfo().electionType().
+              toLowerCase(Locale.getDefault()).replace(" ", "_"));
+    sb.append('-');
+    sb.append(DateTimeFormatter.ISO_LOCAL_DATE.format(election_datetime));
+    sb.append("-report-");
+    sb.append(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(report_datetime).replace(":", "_"));
+    sb.append(".xlsx");
+    
+    return sb.toString();
+  }
+  
+  /**
+   * @return the filename for the PDF version of this report.
+   */
+  public String filenamePDF() {
+    return filenameExcel().replaceAll(".xlsx$", ".pdf");
   }
 }

--- a/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
+++ b/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
@@ -22,6 +22,7 @@ us.freeandfair.corla.endpoint.CVRDownload
 us.freeandfair.corla.endpoint.CVRDownloadByCounty
 us.freeandfair.corla.endpoint.CVRDownloadByID
 us.freeandfair.corla.endpoint.CVRExportImport
+us.freeandfair.corla.endpoint.CVRToAuditDownload
 us.freeandfair.corla.endpoint.CVRToAuditList
 us.freeandfair.corla.endpoint.DoSDashboardASMState
 us.freeandfair.corla.endpoint.DoSDashboardRefresh


### PR DESCRIPTION
This adds a new endpoint, with the same API as `/cvr-to-audit-list`, called `/cvr-to-audit-download`; the only difference is that it downloads a CSV file instead of providing a JSON list.

It also explicitly runs the server in AWT headless mode, to prevent AWT from being started when Excel files are generated, and adds reasonable filenames for all downloadable files.