### PR TITLE
Fix Estimates of Remaining Ballots to Audit

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -542,7 +542,7 @@ public final class ComparisonAuditController {
                        the_audit_cvr.id() + " for county " + the_cdb.id() + 
                        ", cvr " + the_cvr_under_audit.id());
     }
-
+    Persistence.flush();
     updateCVRUnderAudit(the_cdb);
     the_cdb.
         setEstimatedBallotsToAudit(computeEstimatedBallotsToAudit(the_cdb) -
@@ -648,8 +648,10 @@ public final class ComparisonAuditController {
         for (int i = 0; i < the_count; i++) {
           ca.recordDiscrepancy(discrepancy.getAsInt());
         }
+        discrepancies.add(ca.auditReason());
       }
-      discrepancies.add(ca.auditReason());
+      ca.signalBallotAudited();
+      Persistence.saveOrUpdate(ca);
     }
     
     for (final CVRContestInfo ci : the_audit_cvr.contestInfo()) {
@@ -698,8 +700,10 @@ public final class ComparisonAuditController {
         for (int i = 0; i < the_count; i++) {
           ca.removeDiscrepancy(discrepancy.getAsInt());
         }
+        discrepancies.remove(ca.auditReason());
       }
-      discrepancies.remove(ca.auditReason());
+      ca.signalBallotAudited();
+      Persistence.saveOrUpdate(ca);
     }
     
     for (final CVRContestInfo ci : the_audit_cvr.contestInfo()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
@@ -243,7 +243,7 @@ public class CVRAuditInfo implements PersistentEntity, Serializable {
    * as a disagreement in a contest audited for that reason.
    */
   public Set<AuditReason> disagreement() {
-    return Collections.unmodifiableSet(my_discrepancy);
+    return Collections.unmodifiableSet(my_disagreement);
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
@@ -711,7 +711,7 @@ public class CountyContestComparisonAudit implements PersistentEntity, Serializa
       if (my_contest_result.losers().isEmpty()) {
         // if there are no losers, we'll just negate this number - even though in 
         // real life, we wouldn't be auditing the contest at all
-        raw_result = Math.min(raw_result, -winner_change);
+        raw_result = Math.max(raw_result, -winner_change);
       } else {
         for (final String loser : my_contest_result.losers()) {
           final int loser_change;


### PR DESCRIPTION
This fixes several issues (some of which don't have tickets but were reported in testing) related to computation of remaining ballots to audit, computation of discrepancies in certain cases, and report generation. Essentially:

- during tabulation, the `losers` set for each contest was incompletely initialized: it only included one choice with each vote total, so if multiple choices got 0 votes, only one was a `loser` and the others... disappeared. That made the discrepancy calculations unpredictable - even though the math behind them was correct, the data set they were working from was wrong. This is also why reports only included a single candidate that received 0 votes. This has been fixed.
- the inconsistency in the remaining number of ballots to audit arose from a calculation (referenced in #695) that we were doing to give an estimate of that remaining number based on discrepancy rates. It was using the percentage of audited ballots with discrepancies _at the time of recalculation_, but only recalculating when a discrepancy was reported. So, discrepancies that occurred earlier had a larger impact on the estimate than if they occurred later, because they represented a larger percentage of the audited ballots. The _optimistic_ estimate - the one from the RLA computation that uses the numbers of discrepancies detected but assumes no discrepancies going forward - was always correct, and the audit calculations as far as finishing the audit were always correct, but that was not what was being displayed. 

Closes #699 