### PR TITLE
Show ACVR comparisons: test/corla-acvrs.psql

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,11 @@ Contents:
     * Regent contest has a very wide margin of 123-14 out of 165 ballots = 66.1%
  and appears on all CVRs
 
-        `Sample size = 15 for margin 66.1%, risk 10%, gamma 1.1, or1 0.01, or2 0.01, ur1 0.01, ur2 0.01, roundUp1 1, roundUp2 1`
+  	`Sample size =  8 for margin 66.1%, risk 10%, gamma 1.03905, o1 0, o2 0, u1 0, u2 0`
+	`Sample size = 10 for margin 66.1%, risk 10%, gamma 1.03905, o1 1, o2 0, u1 0, u2 0`
+	`Sample size = 18 for margin 66.1%, risk 10%, gamma 1.03905, o1 0, o2 1, u1 0, u2 0`
+	`Sample size =  7 for margin 66.1%, risk 10%, gamma 1.03905, o1 0, o2 0, u1 1, u2 0`
+	`Sample size =  6 for margin 66.1%, risk 10%, gamma 1.03905, o1 0, o2 0, u1 0, u2 1`
 
     * COUNTY COMMISSIONER DISTRICT 3 has a wide margin of (27-12)/46 = 32.6% 
     and does not appear on all the CVRs.

--- a/test/corla-acvrs.psql
+++ b/test/corla-acvrs.psql
@@ -1,0 +1,18 @@
+-- Show information about all ACVR entries. In particular:
+--  For all random selections, compare ACVRs with their CVRs, by contest
+-- Note that a "discrepancy" column entry appears if ANY of the contests on the ACVR have a discrepancy
+-- Note that some CVRs may be selected multiple times, and each selection shows up here.
+--  The RLA algorithm takes matches and discrepancies into account for each selection.
+
+SELECT cai.index as selection, dashboard_id AS county, imprinted_id, record_type, timestamp, counted, disagreement,
+   discrepancy, cci_a.comment, cci_a.consensus, cci_s.contest_id, cai.cvr_id, cci_s.choices, acvr_id, cci_a.choices
+ FROM cvr_audit_info AS cai
+ INNER JOIN cast_vote_record AS cvr
+   ON cai.acvr_id = cvr.id
+ LEFT JOIN cvr_contest_info AS cci_s
+   ON cai.cvr_id = cci_s.cvr_id
+ INNER JOIN cvr_contest_info AS cci_a
+   ON cai.acvr_id = cci_a.cvr_id
+     AND cci_a.contest_id = cci_s.contest_id
+ ORDER BY cai.index, cci_s.contest_id 
+;

--- a/test/corla-acvrs.psql
+++ b/test/corla-acvrs.psql
@@ -7,11 +7,11 @@
 SELECT cai.index as selection, dashboard_id AS county, imprinted_id, record_type, timestamp, counted, disagreement,
    discrepancy, cci_a.comment, cci_a.consensus, cci_s.contest_id, cai.cvr_id, cci_s.choices, acvr_id, cci_a.choices
  FROM cvr_audit_info AS cai
- INNER JOIN cast_vote_record AS cvr
+ LEFT JOIN cast_vote_record AS cvr
    ON cai.acvr_id = cvr.id
  LEFT JOIN cvr_contest_info AS cci_s
    ON cai.cvr_id = cci_s.cvr_id
- INNER JOIN cvr_contest_info AS cci_a
+ LEFT JOIN cvr_contest_info AS cci_a
    ON cai.acvr_id = cci_a.cvr_id
      AND cci_a.contest_id = cci_s.contest_id
  ORDER BY cai.index, cci_s.contest_id 


### PR DESCRIPTION
-- Show information about all ACVR entries. In particular:
--  For all random selections, compare ACVRs with their CVRs, by contest
-- Note that a "discrepancy" column entry appears if ANY of the contests on the ACVR have a discrepancy
-- Note that some CVRs may be selected multiple times, and each selection shows up here.
--  The RLA algorithm takes matches and discrepancies into account for each selection.