### PR TITLE
Add Contest Discrepancies to DoS Dashboard, Make Logging More Sane

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import javax.persistence.PersistenceException;
 
+import org.apache.log4j.Level;
 import org.eclipse.jetty.http.HttpStatus;
 
 import spark.Request;
@@ -565,8 +566,18 @@ public abstract class AbstractEndpoint implements Endpoint {
    * @return the type of authorization required to use this endpoint.
    * The default is NONE.
    */
+  @Override
   public AuthorizationType requiredAuthorization() {
     return AuthorizationType.NONE;
+  }
+  
+  /**
+   * @return the priority level at which the endpoint's activity will be
+   * logged. The default is Priority.INFO.
+   */
+  @Override
+  public Level logLevel() {
+    return Level.INFO;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -396,7 +396,8 @@ public abstract class AbstractEndpoint implements Endpoint {
   public void before(final Request the_request, final Response the_response) {
     reset();
     my_log_entries.set(new ArrayList<LogEntry>());
-    Main.LOGGER.info("endpoint " + endpointName() + " hit by " + the_request.host());
+    Main.LOGGER.log(logLevel(), 
+                    "endpoint " + endpointName() + " hit by " + the_request.host());
     // make sure we get all the HTTP post parameters, if there are any, before
     // anything has a chance to read the request body before Spark
     the_request.queryParams();
@@ -442,13 +443,15 @@ public abstract class AbstractEndpoint implements Endpoint {
    */
   private void sendToLogger(final LogEntry the_log_entry) {
     if (the_log_entry.resultCode() == null) {
-      Main.LOGGER.info(the_log_entry.information() + " by " + 
-                       the_log_entry.authenticationData() + " from " + 
-                       the_log_entry.clientHost());
+      Main.LOGGER.log(logLevel(), 
+                      the_log_entry.information() + " by " + 
+                      the_log_entry.authenticationData() + " from " + 
+                      the_log_entry.clientHost());
     } else if (HttpStatus.isSuccess(the_log_entry.resultCode())) {
-      Main.LOGGER.info("successful " + the_log_entry.information() + " by " + 
-                       the_log_entry.authenticationData() + " from " + 
-                       the_log_entry.clientHost());
+      Main.LOGGER.log(logLevel(), 
+                      "successful " + the_log_entry.information() + " by " + 
+                      the_log_entry.authenticationData() + " from " + 
+                      the_log_entry.clientHost());
     } else {
       Main.LOGGER.error("error " + the_log_entry.resultCode() + " " + 
                         the_log_entry.information() + " by " + 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardDashboardASMState.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -41,6 +43,14 @@ public class AuditBoardDashboardASMState extends AbstractAuditBoardDashboardEndp
     return "/audit-board-asm-state";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Level logLevel() {
+    return Level.DEBUG;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -50,6 +52,14 @@ public class CVRDownloadByID extends AbstractEndpoint {
     return AuthorizationType.EITHER;
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Level logLevel() {
+    return Level.DEBUG;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -48,6 +50,14 @@ public class ContestDownloadByID extends AbstractEndpoint {
   @Override
   public AuthorizationType requiredAuthorization() {
     return AuthorizationType.EITHER;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Level logLevel() {
+    return Level.DEBUG;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardASMState.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -41,6 +43,14 @@ public class CountyDashboardASMState extends AbstractCountyDashboardEndpoint {
     return "/county-asm-state";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Level logLevel() {
+    return Level.DEBUG;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
@@ -13,6 +13,8 @@ package us.freeandfair.corla.endpoint;
 
 import javax.persistence.PersistenceException;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -45,6 +47,14 @@ public class CountyDashboardRefresh extends AbstractCountyDashboardEndpoint {
   @Override
   public String endpointName() {
     return "/county-dashboard";
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Level logLevel() {
+    return Level.DEBUG;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardASMState.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -41,6 +43,14 @@ public class DoSDashboardASMState extends AbstractDoSDashboardEndpoint {
     return "/dos-asm-state";
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Level logLevel() {
+    return Level.DEBUG;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
@@ -13,6 +13,8 @@ package us.freeandfair.corla.endpoint;
 
 import javax.persistence.PersistenceException;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -44,6 +46,14 @@ public class DoSDashboardRefresh extends AbstractDoSDashboardEndpoint {
   @Override
   public String endpointName() {
     return "/dos-dashboard";
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Level logLevel() {
+    return Level.DEBUG;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Endpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Endpoint.java
@@ -11,6 +11,8 @@
 
 package us.freeandfair.corla.endpoint;
 
+import org.apache.log4j.Level;
+
 import spark.Request;
 import spark.Response;
 
@@ -77,6 +79,12 @@ public interface Endpoint {
    * @return the required authorization type for this endpoint.
    */
   AuthorizationType requiredAuthorization();
+  
+  /**
+   * @return the priority level at which the activity of this endpoint should
+   * be logged.
+   */
+  Level logLevel(); 
   
   /**
    * The authorization types.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -13,11 +13,12 @@
 package us.freeandfair.corla.json;
 
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import javax.persistence.PersistenceException;
 
@@ -73,7 +74,7 @@ public class CountyDashboardRefreshResponse {
    * The general information.
    * @todo this needs to be connected to something
    */
-  private final Map<String, String> my_general_information;
+  private final SortedMap<String, String> my_general_information;
   
   /**
    * The audit board members.
@@ -113,12 +114,12 @@ public class CountyDashboardRefreshResponse {
   /**
    * The contests on the ballot (by ID).
    */
-  private final Set<Long> my_contests;
+  private final List<Long> my_contests;
   
   /**
    * The contests under audit, with reasons.
    */
-  private final Map<Long, String> my_contests_under_audit;
+  private final SortedMap<Long, String> my_contests_under_audit;
   
   /**
    * The date and time of the audit. 
@@ -229,7 +230,8 @@ public class CountyDashboardRefreshResponse {
   protected CountyDashboardRefreshResponse(final Long the_id,
                                            final ASMState the_asm_state,
                                            final ASMState the_audit_board_asm_state,
-                                           final Map<String, String> the_general_information,
+                                           final SortedMap<String, String> 
+                                               the_general_information,
                                            final AuditBoard the_audit_board, 
                                            final String the_ballot_manifest_hash,
                                            final Instant the_ballot_manifest_timestamp,
@@ -237,8 +239,9 @@ public class CountyDashboardRefreshResponse {
                                            final String the_cvr_export_hash,
                                            final Instant the_cvr_export_timestamp,
                                            final String the_cvr_export_filename,
-                                           final Set<Long> the_contests,
-                                           final Map<Long, String> the_contests_under_audit,
+                                           final List<Long> the_contests,
+                                           final SortedMap<Long, String> 
+                                               the_contests_under_audit,
                                            final Instant the_audit_time,
                                            final Integer the_estimated_ballots_to_audit,
                                            final Integer the_optimistic_ballots_to_audit,
@@ -307,7 +310,7 @@ public class CountyDashboardRefreshResponse {
     final Long county_id = county.id();
 
     // general information doesn't exist yet
-    final Map<String, String> general_information = new HashMap<String, String>();
+    final SortedMap<String, String> general_information = new TreeMap<String, String>();
 
     final UploadedFile manifest = 
         UploadedFileQueries.matching(county_id, 
@@ -332,8 +335,8 @@ public class CountyDashboardRefreshResponse {
     }
     
     // contests and contests under audit
-    final Set<Long> contests = new HashSet<Long>();
-    final Map<Long, String> contests_under_audit = new HashMap<Long, String>();
+    final List<Long> contests = new ArrayList<Long>();
+    final SortedMap<Long, String> contests_under_audit = new TreeMap<Long, String>();
     if (the_dashboard.cvrUploadTimestamp() != null &&
         the_dashboard.manifestUploadTimestamp() != null) {
       // only add contests if uploads are done
@@ -348,6 +351,8 @@ public class CountyDashboardRefreshResponse {
         }
       }
     }
+    
+    Collections.sort(contests);
     
     // ASM states
     final CountyDashboardASM asm = ASMUtilities.asmFor(CountyDashboardASM.class, 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
@@ -163,8 +163,10 @@ public class DoSDashboardRefreshResponse {
                 Math.max(estimated, 
                          Math.max(0, ccca.estimatedBallotsToAudit() - 
                                      ccca.dashboard().auditedPrefixLength()));
+            
+            // possible discrepancy types range from -2 to 2 inclusive,
+            // and we provide them all in the refresh response
             for (int i = -2; i <= 2; i++) {
-              // get the discrepancy counts of various types
               if (discrepancy.get(i) == null) {
                 discrepancy.put(i,  0);
               }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
@@ -11,11 +11,13 @@
 
 package us.freeandfair.corla.json;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import javax.persistence.PersistenceException;
 
@@ -24,7 +26,6 @@ import us.freeandfair.corla.asm.ASMUtilities;
 import us.freeandfair.corla.asm.DoSDashboardASM;
 import us.freeandfair.corla.model.AuditInfo;
 import us.freeandfair.corla.model.AuditReason;
-import us.freeandfair.corla.model.Contest;
 import us.freeandfair.corla.model.ContestToAudit;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyContestComparisonAudit;
@@ -32,7 +33,6 @@ import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.model.DoSDashboard;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.CountyContestComparisonAuditQueries;
-import us.freeandfair.corla.util.Pair;
 import us.freeandfair.corla.util.SuppressFBWarnings;
 
 /**
@@ -56,27 +56,32 @@ public class DoSDashboardRefreshResponse {
   /**
    * A map from audited contests to audit reasons.
    */
-  private final Map<Long, AuditReason> my_audited_contests;
+  private final SortedMap<Long, AuditReason> my_audited_contests;
   
   /**
    * A map from audited contests to estimated ballots left to audit.
    */
-  private final Map<Long, Integer> my_estimated_ballots_to_audit;
+  private final SortedMap<Long, Integer> my_estimated_ballots_to_audit;
   
   /**
    * A map from audited contests to optimistic ballots left to audit.
    */
-  private final Map<Long, Integer> my_optimistic_ballots_to_audit;
+  private final SortedMap<Long, Integer> my_optimistic_ballots_to_audit;
+  
+  /**
+   * A map from audited contests to discrepancy count maps.
+   */
+  private final SortedMap<Long, Map<Integer, Integer>> my_discrepancy_count;
   
   /**
    * A map from county IDs to county status.
    */
-  private final Map<Long, CountyDashboardRefreshResponse> my_county_status;
+  private final SortedMap<Long, CountyDashboardRefreshResponse> my_county_status;
   
   /**
    * A set of contests selected for full hand count.
    */
-  private final Set<Long> my_hand_count_contests;
+  private final List<Long> my_hand_count_contests;
   
   /**
    * The audit info.
@@ -88,25 +93,35 @@ public class DoSDashboardRefreshResponse {
    * 
    * @param the_asm_state The ASM state.
    * @param the_audited_contests The audited contests.
+   * @param the_estimated_ballots_to_audit The estimated ballots to audit, 
+   * by contest.
+   * @param the_optimistic_ballots_to_audit The optimistic ballots to audit, 
+   * by contest.
+   * @param the_discrepancy_count The discrepancy count for each discrepancy type,
+   * by contest.
    * @param the_county_status The county statuses.
    * @param the_hand_count_contests The hand count contests.
    * @param the_audit_info The election info.
    */
   @SuppressWarnings("PMD.ExcessiveParameterList")
   protected DoSDashboardRefreshResponse(final ASMState the_asm_state,
-                                        final Map<Long, AuditReason> the_audited_contests,
-                                        final Map<Long, Integer> 
+                                        final SortedMap<Long, AuditReason> 
+                                           the_audited_contests,
+                                        final SortedMap<Long, Integer> 
                                            the_estimated_ballots_to_audit,
-                                        final Map<Long, Integer>
+                                        final SortedMap<Long, Integer>
                                            the_optimistic_ballots_to_audit,
-                                        final Map<Long, CountyDashboardRefreshResponse> 
+                                        final SortedMap<Long, Map<Integer, Integer>>
+                                           the_discrepancy_counts,
+                                        final SortedMap<Long, CountyDashboardRefreshResponse> 
                                            the_county_status,
-                                        final Set<Long> the_hand_count_contests,
+                                        final List<Long> the_hand_count_contests,
                                         final AuditInfo the_audit_info) {
     my_asm_state = the_asm_state;
     my_audited_contests = the_audited_contests;
     my_estimated_ballots_to_audit = the_estimated_ballots_to_audit;
     my_optimistic_ballots_to_audit = the_optimistic_ballots_to_audit;
+    my_discrepancy_count = the_discrepancy_counts;
     my_county_status = the_county_status;
     my_hand_count_contests = the_hand_count_contests;
     my_audit_info = the_audit_info;
@@ -120,22 +135,45 @@ public class DoSDashboardRefreshResponse {
    * @exception NullPointerException if necessary information to construct the
    * response does not exist.
    */
+  @SuppressWarnings("checkstyle:magicnumber")
   public static DoSDashboardRefreshResponse 
       createResponse(final DoSDashboard the_dashboard) {
     // construct the various audit info from the contests to audit in the dashboard
-    final Map<Long, AuditReason> audited_contests = 
-        new HashMap<Long, AuditReason>();
-    final Map<Long, Integer> estimated_ballots_to_audit = new HashMap<Long, Integer>();
-    final Map<Long, Integer> optimistic_ballots_to_audit = new HashMap<Long, Integer>();
-    final Set<Long> hand_count_contests = new HashSet<Long>();
+    final SortedMap<Long, AuditReason> audited_contests = 
+        new TreeMap<Long, AuditReason>();
+    final SortedMap<Long, Integer> estimated_ballots_to_audit = new TreeMap<Long, Integer>();
+    final SortedMap<Long, Integer> optimistic_ballots_to_audit = new TreeMap<Long, Integer>();
+    final SortedMap<Long, Map<Integer, Integer>> discrepancy_count = new TreeMap<>();
+    final List<Long> hand_count_contests = new ArrayList<Long>();
     
     for (final ContestToAudit cta : the_dashboard.contestsToAudit()) {
       switch (cta.audit()) {
         case COMPARISON:
           audited_contests.put(cta.contest().id(), cta.reason());
-          final Pair<Integer, Integer> estimates = ballotsToAudit(cta.contest());
-          estimated_ballots_to_audit.put(cta.contest().id(), estimates.first());
-          optimistic_ballots_to_audit.put(cta.contest().id(), estimates.second());
+          final Map<Integer, Integer> discrepancy = new HashMap<>();
+          int optimistic = Integer.MIN_VALUE;
+          int estimated = Integer.MIN_VALUE;
+          for (final CountyContestComparisonAudit ccca : 
+               CountyContestComparisonAuditQueries.matching(cta.contest())) {
+            optimistic = 
+                Math.max(optimistic, 
+                         Math.max(0, ccca.optimisticBallotsToAudit() - 
+                                     ccca.dashboard().auditedPrefixLength()));
+            estimated = 
+                Math.max(estimated, 
+                         Math.max(0, ccca.estimatedBallotsToAudit() - 
+                                     ccca.dashboard().auditedPrefixLength()));
+            for (int i = -2; i <= 2; i++) {
+              // get the discrepancy counts of various types
+              if (discrepancy.get(i) == null) {
+                discrepancy.put(i,  0);
+              }
+              discrepancy.put(i, discrepancy.get(i) + ccca.discrepancyCount(i));
+            }
+          }
+          estimated_ballots_to_audit.put(cta.contest().id(), optimistic);
+          optimistic_ballots_to_audit.put(cta.contest().id(), estimated);
+          discrepancy_count.put(cta.contest().id(), discrepancy);
           break;
           
         case HAND_COUNT:
@@ -145,6 +183,9 @@ public class DoSDashboardRefreshResponse {
         default:
       }
     }
+    
+    Collections.sort(hand_count_contests);
+    
     // status
     final DoSDashboardASM asm = 
         ASMUtilities.asmFor(DoSDashboardASM.class, DoSDashboardASM.IDENTITY);
@@ -154,32 +195,10 @@ public class DoSDashboardRefreshResponse {
                                            audited_contests,
                                            estimated_ballots_to_audit,
                                            optimistic_ballots_to_audit,
+                                           discrepancy_count,
                                            countyStatusMap(),
                                            hand_count_contests,
                                            the_dashboard.auditInfo());
-  }
-  
-  /**
-   * Gets the estimated and optimistic ballots to audit for a contest under audit.
-   * 
-   * @param the_contest The contest
-   * @return a pair <estimated, optimistic> of numbers of ballots to audit.
-   */
-  private static Pair<Integer, Integer> ballotsToAudit(final Contest the_contest) {
-    int optimistic = Integer.MIN_VALUE;
-    int estimated = Integer.MIN_VALUE;
-    for (final CountyContestComparisonAudit ccca : 
-         CountyContestComparisonAuditQueries.matching(the_contest)) {
-      optimistic = 
-          Math.max(optimistic, 
-                   Math.max(0, ccca.optimisticBallotsToAudit() - 
-                               ccca.dashboard().auditedPrefixLength()));
-      estimated = 
-          Math.max(estimated, 
-                   Math.max(0, ccca.estimatedBallotsToAudit() - 
-                               ccca.dashboard().auditedPrefixLength()));    
-    }
-    return new Pair<Integer, Integer>(Math.max(0, estimated), Math.max(0, optimistic));
   }
   
   /**
@@ -187,9 +206,9 @@ public class DoSDashboardRefreshResponse {
    * 
    * @return a map from county identifiers to statuses.
    */
-  private static Map<Long, CountyDashboardRefreshResponse> countyStatusMap() {
-    final Map<Long, CountyDashboardRefreshResponse> status_map = 
-        new HashMap<Long, CountyDashboardRefreshResponse>();
+  private static SortedMap<Long, CountyDashboardRefreshResponse> countyStatusMap() {
+    final SortedMap<Long, CountyDashboardRefreshResponse> status_map = 
+        new TreeMap<Long, CountyDashboardRefreshResponse>();
     final List<County> counties = Persistence.getAll(County.class);
     
     for (final County c : counties) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/ContestQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/ContestQueries.java
@@ -64,7 +64,7 @@ public final class ContestQueries {
       }
       cq.select(root);
       cq.where(cb.or(disjuncts.toArray(new Predicate[disjuncts.size()])));
-      cq.orderBy(cb.asc(root.get("my_county").get("my_name")), 
+      cq.orderBy(cb.asc(root.get("my_county").get("my_id")), 
                  cb.asc(root.get("my_sequence_number")));
       final TypedQuery<Contest> query = s.createQuery(cq);
       result = query.getResultList();  

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -39,7 +39,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
-import us.freeandfair.corla.Main;
 import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.model.AuditReason;
 import us.freeandfair.corla.model.CVRAuditInfo;
@@ -131,7 +130,6 @@ public class CountyReport {
     my_driving_contest_results = new ArrayList<CountyContestResult>();
     my_cdb = 
         Persistence.getByID(my_county.id(), CountyDashboard.class);
-    Main.LOGGER.info("driving contests: " + my_cdb.drivingContests());
     for (final CountyContestResult ccr : 
          CountyContestResultQueries.forCounty(my_county)) {
       if (my_cdb.drivingContests().contains(ccr.contest())) {
@@ -144,7 +142,6 @@ public class CountyReport {
       final List<CVRAuditInfo> cvrs_to_audit = 
           ComparisonAuditController.cvrsToAuditInRound(my_cdb, r.number());
       cvrs_to_audit.sort(new CVRAuditInfo.BallotOrderComparator());
-      Main.LOGGER.info("cvrs to audit: " + cvrs_to_audit);
       my_cvrs_to_audit_by_round.put(r.number(), cvrs_to_audit);
     }
     my_dosdb = Persistence.getByID(DoSDashboard.ID, DoSDashboard.class);
@@ -202,7 +199,6 @@ public class CountyReport {
     workbook.write(baos);
     baos.flush();
     baos.close();
-    Main.LOGGER.info("output stream size: " + baos.size());
     workbook.close();
     return baos.toByteArray();
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
@@ -41,7 +41,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
-import us.freeandfair.corla.Main;
 import us.freeandfair.corla.model.AuditReason;
 import us.freeandfair.corla.model.CVRAuditInfo;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
@@ -129,7 +128,6 @@ public class StateReport {
     workbook.write(baos);
     baos.flush();
     baos.close();
-    Main.LOGGER.info("output stream size: " + baos.size());
     workbook.close();
     return baos.toByteArray();
   }


### PR DESCRIPTION
This adds contest discrepancy information to the DoS dashboard refresh, and also reduces our syslog output by switching some endpoints that are frequently used and read-only to DEBUG level instead of INFO level.
