### PR TITLE
Eliminate the "Write-in" candidate, suboptimally.

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/ContestJsonAdapter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/ContestJsonAdapter.java
@@ -76,6 +76,7 @@ public final class ContestJsonAdapter extends TypeAdapter<Contest> {
    * @param the_info The object to write.
    */ 
   @Override
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   public void write(final JsonWriter the_writer, 
                     final Contest the_contest) 
       throws IOException {
@@ -87,7 +88,9 @@ public final class ContestJsonAdapter extends TypeAdapter<Contest> {
     the_writer.name(CHOICES);
     the_writer.beginArray();
     for (final Choice c : the_contest.choices()) {
-      the_writer.jsonValue(Main.GSON.toJson(Persistence.unproxy(c)));
+      if (!"Write-in".equals(c.name())) {
+        the_writer.jsonValue(Main.GSON.toJson(Persistence.unproxy(c)));
+      }
     }
     the_writer.endArray();
     the_writer.name(VOTES_ALLOWED).value(the_contest.votesAllowed());

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -390,6 +390,9 @@ public class CountyReport {
       cell.setCellValue("Diluted Margin %");
       
       for (final String choice : ccr.rankedChoices()) {
+        if ("Write-in".equals(choice)) {
+          continue;
+        }
         row = summary_sheet.createRow(row_number++);
         max_cell_number = Math.max(max_cell_number, cell_number);
         cell_number = 0;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
@@ -337,6 +337,9 @@ public class StateReport {
           cell.setCellValue("Diluted Margin %");
 
           for (final String choice : ccr.rankedChoices()) {
+            if ("Write-in".equals(choice)) {
+              continue;
+            }
             row = summary_sheet.createRow(row_number++);
             max_cell_number = Math.max(max_cell_number, cell_number);
             cell_number = 0;


### PR DESCRIPTION
This is a quick elimination of the "Write-in" candidate from user interfaces and reports, pending a better-structured elimination of it from contest choices entirely.