### PR TITLE
Phase 3 Amendment 2 Server Changes (Not Including Reports)

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMEvent.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMEvent.java
@@ -29,7 +29,6 @@ public interface ASMEvent extends Event {
     DOS_START_ROUND_EVENT, // public inbound event
     DOS_ROUND_COMPLETE_EVENT, // private internal event
     AUDIT_EVENT, // private internal event
-    INDICATE_FULL_HAND_COUNT_CONTEST_EVENT, // public inbound event
     DOS_COUNTY_AUDIT_COMPLETE_EVENT, // private internal event
     DOS_AUDIT_COMPLETE_EVENT, // private internal event
     PUBLISH_AUDIT_REPORT_EVENT // public inbound event

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMEventToEndpointRelation.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMEventToEndpointRelation.java
@@ -66,9 +66,6 @@ public class ASMEventToEndpointRelation {
         DOS_START_ROUND_EVENT,
         UNIMPLEMENTED));
     my_relation.add(new Pair<ASMEvent, String>(
-        INDICATE_FULL_HAND_COUNT_CONTEST_EVENT,
-        UNIMPLEMENTED));
-    my_relation.add(new Pair<ASMEvent, String>(
         PUBLISH_AUDIT_REPORT_EVENT,
         UNIMPLEMENTED));
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
@@ -52,7 +52,6 @@ public interface ASMTransitionFunction {
                         DOS_AUDIT_ONGOING)),
     E(new ASMTransition(DOS_AUDIT_ONGOING, 
                         SetCreator.setOf(AUDIT_EVENT,
-                                         INDICATE_FULL_HAND_COUNT_CONTEST_EVENT, 
                                          DOS_COUNTY_AUDIT_COMPLETE_EVENT,
                                          DOS_START_ROUND_EVENT),
                         DOS_AUDIT_ONGOING)),
@@ -92,67 +91,67 @@ public interface ASMTransitionFunction {
     public ASMTransition value() {
       return my_transition;
     }
-  }
-  
-  /**
-   * The County Board Dashboard's transition function.
-   * @trace asm.county_dashboard_next_state
-   */
-  enum CountyDashboardTransitionFunction implements ASMTransitionFunction {
-    A(new ASMTransition(COUNTY_INITIAL_STATE,
-                        UPLOAD_BALLOT_MANIFEST_EVENT,
-                        BALLOT_MANIFEST_OK)),
-    B(new ASMTransition(COUNTY_INITIAL_STATE,
-                        UPLOAD_CVRS_EVENT,
-                        CVRS_OK)),
-    C(new ASMTransition(BALLOT_MANIFEST_OK, 
-                        UPLOAD_CVRS_EVENT,
-                        BALLOT_MANIFEST_AND_CVRS_OK)),
-    D(new ASMTransition(BALLOT_MANIFEST_OK,
-                        UPLOAD_BALLOT_MANIFEST_EVENT,
-                        BALLOT_MANIFEST_OK)),
-    E(new ASMTransition(CVRS_OK,
-                        UPLOAD_BALLOT_MANIFEST_EVENT,
-                        BALLOT_MANIFEST_AND_CVRS_OK)),
-    F(new ASMTransition(CVRS_OK,
-                        UPLOAD_CVRS_EVENT,
-                        CVRS_OK)),
-    G(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
-                        SetCreator.setOf(UPLOAD_BALLOT_MANIFEST_EVENT, 
-                                         UPLOAD_CVRS_EVENT),
-                        BALLOT_MANIFEST_AND_CVRS_OK)),
-    H(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
-                        COUNTY_START_AUDIT_EVENT,
-                        COUNTY_AUDIT_UNDERWAY)),
-    I(new ASMTransition(COUNTY_AUDIT_UNDERWAY, 
-                        COUNTY_AUDIT_COMPLETE_EVENT,
-                        COUNTY_AUDIT_COMPLETE)),
-    J(new ASMTransition(SetCreator.setOf(COUNTY_INITIAL_STATE,
-                                         BALLOT_MANIFEST_OK,
-                                         CVRS_OK),
-                        COUNTY_START_AUDIT_EVENT,
-                        DEADLINE_MISSED));
 
     /**
-     * A single transition.
+     * The County Board Dashboard's transition function.
+     * @trace asm.county_dashboard_next_state
      */
-    @SuppressWarnings("PMD.ConstantsInInterface")
-    private final transient ASMTransition my_transition;
+    enum CountyDashboardTransitionFunction implements ASMTransitionFunction {
+      A(new ASMTransition(COUNTY_INITIAL_STATE,
+                          UPLOAD_BALLOT_MANIFEST_EVENT,
+                          BALLOT_MANIFEST_OK)),
+      B(new ASMTransition(COUNTY_INITIAL_STATE,
+                          UPLOAD_CVRS_EVENT,
+                          CVRS_OK)),
+      C(new ASMTransition(BALLOT_MANIFEST_OK, 
+                          UPLOAD_CVRS_EVENT,
+                          BALLOT_MANIFEST_AND_CVRS_OK)),
+      D(new ASMTransition(BALLOT_MANIFEST_OK,
+                          UPLOAD_BALLOT_MANIFEST_EVENT,
+                          BALLOT_MANIFEST_OK)),
+      E(new ASMTransition(CVRS_OK,
+                          UPLOAD_BALLOT_MANIFEST_EVENT,
+                          BALLOT_MANIFEST_AND_CVRS_OK)),
+      F(new ASMTransition(CVRS_OK,
+                          UPLOAD_CVRS_EVENT,
+                          CVRS_OK)),
+      G(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
+                          SetCreator.setOf(UPLOAD_BALLOT_MANIFEST_EVENT, 
+                                           UPLOAD_CVRS_EVENT),
+                          BALLOT_MANIFEST_AND_CVRS_OK)),
+      H(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
+                          COUNTY_START_AUDIT_EVENT,
+                          COUNTY_AUDIT_UNDERWAY)),
+      I(new ASMTransition(COUNTY_AUDIT_UNDERWAY, 
+                          COUNTY_AUDIT_COMPLETE_EVENT,
+                          COUNTY_AUDIT_COMPLETE)),
+      J(new ASMTransition(SetCreator.setOf(COUNTY_INITIAL_STATE,
+                                           BALLOT_MANIFEST_OK,
+                                           CVRS_OK),
+                          COUNTY_START_AUDIT_EVENT,
+                          DEADLINE_MISSED));
     
-    /**
-     * Create a transition.
-     * @param the_pair the (current state, event) pair.
-     * @param the_state the state transitioned to when the pair is witnessed.
-     */
-    CountyDashboardTransitionFunction(final ASMTransition the_transition) {
-      my_transition = the_transition;
-    }
-    
-    /**
-     * @return the pair encoding this enumeration.
-     */
-    public ASMTransition value() {
-      return my_transition;
+      /**
+       * A single transition.
+       */
+      @SuppressWarnings("PMD.ConstantsInInterface")
+      private final transient ASMTransition my_transition;
+      
+      /**
+       * Create a transition.
+       * @param the_pair the (current state, event) pair.
+       * @param the_state the state transitioned to when the pair is witnessed.
+       */
+      CountyDashboardTransitionFunction(final ASMTransition the_transition) {
+        my_transition = the_transition;
+      }
+      
+      /**
+       * @return the pair encoding this enumeration.
+       */
+      public ASMTransition value() {
+        return my_transition;
+      }
     }
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
@@ -69,13 +69,13 @@ public interface ASMTransitionFunction {
     I(new ASMTransition(DOS_AUDIT_COMPLETE, 
                         PUBLISH_AUDIT_REPORT_EVENT,
                         AUDIT_RESULTS_PUBLISHED));
-    
+
     /**
      * A single transition.
      */
     @SuppressWarnings("PMD.ConstantsInInterface")
     private final transient ASMTransition my_transition;
-    
+
     /**
      * Create a transition.
      * @param the_pair the (current state, event) pair.
@@ -84,77 +84,77 @@ public interface ASMTransitionFunction {
     DoSDashboardTransitionFunction(final ASMTransition the_transition) {
       my_transition = the_transition;
     }
-    
+
     /**
      * @return the pair encoding this enumeration.
      */
     public ASMTransition value() {
       return my_transition;
     }
+  }
+
+  /**
+   * The County Board Dashboard's transition function.
+   * @trace asm.county_dashboard_next_state
+   */
+  enum CountyDashboardTransitionFunction implements ASMTransitionFunction {
+    A(new ASMTransition(COUNTY_INITIAL_STATE,
+                        UPLOAD_BALLOT_MANIFEST_EVENT,
+                        BALLOT_MANIFEST_OK)),
+    B(new ASMTransition(COUNTY_INITIAL_STATE,
+                        UPLOAD_CVRS_EVENT,
+                        CVRS_OK)),
+    C(new ASMTransition(BALLOT_MANIFEST_OK, 
+                        UPLOAD_CVRS_EVENT,
+                        BALLOT_MANIFEST_AND_CVRS_OK)),
+    D(new ASMTransition(BALLOT_MANIFEST_OK,
+                        UPLOAD_BALLOT_MANIFEST_EVENT,
+                        BALLOT_MANIFEST_OK)),
+    E(new ASMTransition(CVRS_OK,
+                        UPLOAD_BALLOT_MANIFEST_EVENT,
+                        BALLOT_MANIFEST_AND_CVRS_OK)),
+    F(new ASMTransition(CVRS_OK,
+                        UPLOAD_CVRS_EVENT,
+                        CVRS_OK)),
+    G(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
+                        SetCreator.setOf(UPLOAD_BALLOT_MANIFEST_EVENT, 
+                                         UPLOAD_CVRS_EVENT),
+                        BALLOT_MANIFEST_AND_CVRS_OK)),
+    H(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
+                        COUNTY_START_AUDIT_EVENT,
+                        COUNTY_AUDIT_UNDERWAY)),
+    I(new ASMTransition(COUNTY_AUDIT_UNDERWAY, 
+                        COUNTY_AUDIT_COMPLETE_EVENT,
+                        COUNTY_AUDIT_COMPLETE)),
+    J(new ASMTransition(SetCreator.setOf(COUNTY_INITIAL_STATE,
+                                         BALLOT_MANIFEST_OK,
+                                         CVRS_OK),
+                        COUNTY_START_AUDIT_EVENT,
+                        DEADLINE_MISSED));
 
     /**
-     * The County Board Dashboard's transition function.
-     * @trace asm.county_dashboard_next_state
+     * A single transition.
      */
-    enum CountyDashboardTransitionFunction implements ASMTransitionFunction {
-      A(new ASMTransition(COUNTY_INITIAL_STATE,
-                          UPLOAD_BALLOT_MANIFEST_EVENT,
-                          BALLOT_MANIFEST_OK)),
-      B(new ASMTransition(COUNTY_INITIAL_STATE,
-                          UPLOAD_CVRS_EVENT,
-                          CVRS_OK)),
-      C(new ASMTransition(BALLOT_MANIFEST_OK, 
-                          UPLOAD_CVRS_EVENT,
-                          BALLOT_MANIFEST_AND_CVRS_OK)),
-      D(new ASMTransition(BALLOT_MANIFEST_OK,
-                          UPLOAD_BALLOT_MANIFEST_EVENT,
-                          BALLOT_MANIFEST_OK)),
-      E(new ASMTransition(CVRS_OK,
-                          UPLOAD_BALLOT_MANIFEST_EVENT,
-                          BALLOT_MANIFEST_AND_CVRS_OK)),
-      F(new ASMTransition(CVRS_OK,
-                          UPLOAD_CVRS_EVENT,
-                          CVRS_OK)),
-      G(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
-                          SetCreator.setOf(UPLOAD_BALLOT_MANIFEST_EVENT, 
-                                           UPLOAD_CVRS_EVENT),
-                          BALLOT_MANIFEST_AND_CVRS_OK)),
-      H(new ASMTransition(BALLOT_MANIFEST_AND_CVRS_OK,
-                          COUNTY_START_AUDIT_EVENT,
-                          COUNTY_AUDIT_UNDERWAY)),
-      I(new ASMTransition(COUNTY_AUDIT_UNDERWAY, 
-                          COUNTY_AUDIT_COMPLETE_EVENT,
-                          COUNTY_AUDIT_COMPLETE)),
-      J(new ASMTransition(SetCreator.setOf(COUNTY_INITIAL_STATE,
-                                           BALLOT_MANIFEST_OK,
-                                           CVRS_OK),
-                          COUNTY_START_AUDIT_EVENT,
-                          DEADLINE_MISSED));
-    
-      /**
-       * A single transition.
-       */
-      @SuppressWarnings("PMD.ConstantsInInterface")
-      private final transient ASMTransition my_transition;
-      
-      /**
-       * Create a transition.
-       * @param the_pair the (current state, event) pair.
-       * @param the_state the state transitioned to when the pair is witnessed.
-       */
-      CountyDashboardTransitionFunction(final ASMTransition the_transition) {
-        my_transition = the_transition;
-      }
-      
-      /**
-       * @return the pair encoding this enumeration.
-       */
-      public ASMTransition value() {
-        return my_transition;
-      }
+    @SuppressWarnings("PMD.ConstantsInInterface")
+    private final transient ASMTransition my_transition;
+
+    /**
+     * Create a transition.
+     * @param the_pair the (current state, event) pair.
+     * @param the_state the state transitioned to when the pair is witnessed.
+     */
+    CountyDashboardTransitionFunction(final ASMTransition the_transition) {
+      my_transition = the_transition;
+    }
+
+    /**
+     * @return the pair encoding this enumeration.
+     */
+    public ASMTransition value() {
+      return my_transition;
     }
   }
-  
+
   /**
    * The Audit Board Dashboard's transition function.
    * @trace asm.audit_board_dashboard_next_state

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/CountyDashboardASM.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/CountyDashboardASM.java
@@ -20,7 +20,7 @@ import javax.persistence.Entity;
 
 import us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent;
 import us.freeandfair.corla.asm.ASMState.CountyDashboardState;
-import us.freeandfair.corla.asm.ASMTransitionFunction.CountyDashboardTransitionFunction;
+import us.freeandfair.corla.asm.ASMTransitionFunction.DoSDashboardTransitionFunction.CountyDashboardTransitionFunction;
 import us.freeandfair.corla.util.SetCreator;
 
 /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/CountyDashboardASM.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/CountyDashboardASM.java
@@ -20,7 +20,7 @@ import javax.persistence.Entity;
 
 import us.freeandfair.corla.asm.ASMEvent.CountyDashboardEvent;
 import us.freeandfair.corla.asm.ASMState.CountyDashboardState;
-import us.freeandfair.corla.asm.ASMTransitionFunction.DoSDashboardTransitionFunction.CountyDashboardTransitionFunction;
+import us.freeandfair.corla.asm.ASMTransitionFunction.CountyDashboardTransitionFunction;
 import us.freeandfair.corla.util.SetCreator;
 
 /**
@@ -35,15 +35,15 @@ public class CountyDashboardASM extends AbstractStateMachine {
   /**
    * The serialVersionUID.
    */
-  private static final long serialVersionUID = 1; 
+  private static final long serialVersionUID = 1;
 
   /**
    * The final states of this ASM.
    */
-  private static final ASMState[] FINAL_STATES = 
+  private static final ASMState[] FINAL_STATES =
       {CountyDashboardState.DEADLINE_MISSED,
        CountyDashboardState.COUNTY_AUDIT_COMPLETE};
-  
+
   /**
    * Create the County Dashboard ASM.
    * 
@@ -59,5 +59,5 @@ public class CountyDashboardASM extends AbstractStateMachine {
           CountyDashboardState.COUNTY_INITIAL_STATE,
           SetCreator.setOf(FINAL_STATES),
           the_county_id);
-  } 
+  }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/UIToASMEventRelation.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/UIToASMEventRelation.java
@@ -56,8 +56,6 @@ public class UIToASMEventRelation {
     my_relation.add(new Pair<UIEvent, ASMEvent>(UNDEFINED, 
         DOS_START_ROUND_EVENT));
     my_relation.add(new Pair<UIEvent, ASMEvent>(UNDEFINED, 
-        INDICATE_FULL_HAND_COUNT_CONTEST_EVENT));
-    my_relation.add(new Pair<UIEvent, ASMEvent>(UNDEFINED, 
         PUBLISH_AUDIT_REPORT_EVENT));
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -307,7 +307,7 @@ public final class ComparisonAuditController {
     }
     
     the_cdb.setAuditedPrefixLength(0);
-    the_cdb.setAuditedRecordCount(0);
+    the_cdb.setAuditedSampleCount(0);
     for (final CountyContestResult ccr : 
          CountyContestResultQueries.forCounty(the_cdb.county())) {
       AuditReason reason = contest_reasons.get(ccr.contest());
@@ -514,7 +514,7 @@ public final class ComparisonAuditController {
         the_cdb.addAuditedBallot();
         final Pair<Set<AuditReason>, Set<AuditReason>> audit_results = 
             audit(the_cdb, the_cvr_under_audit, the_audit_cvr, info.size(), true);
-        the_cdb.setAuditedRecordCount(the_cdb.auditedRecordCount() + info.size());
+        the_cdb.setAuditedSampleCount(the_cdb.auditedSampleCount() + info.size());
         for (final CVRAuditInfo c : info) {
           c.setACVR(the_audit_cvr);
           c.setCounted(true);
@@ -555,10 +555,10 @@ public final class ComparisonAuditController {
     updateCVRUnderAudit(the_cdb);
     the_cdb.
         setEstimatedBallotsToAudit(computeEstimatedBallotsToAudit(the_cdb) -
-                                   the_cdb.auditedRecordCount());
+                                   the_cdb.auditedSampleCount());
     the_cdb.
         setOptimisticBallotsToAudit(computeOptimisticBallotsToAudit(the_cdb) -
-                                    the_cdb.auditedRecordCount());
+                                    the_cdb.auditedSampleCount());
     return result;
   }
   
@@ -760,7 +760,7 @@ public final class ComparisonAuditController {
         cai.setDiscrepancy(audit_results.first());
         cai.setDisagreement(audit_results.second());
         Persistence.saveOrUpdate(cai);
-        the_cdb.setAuditedRecordCount(the_cdb.auditedRecordCount() + 1);
+        the_cdb.setAuditedSampleCount(the_cdb.auditedSampleCount() + 1);
       }
       index = index + 1;
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -134,7 +134,7 @@ public final class ComparisonAuditController {
     final Round round = the_cdb.currentRound();
     if (round != null) {
       result = 
-          CVRAuditInfoQueries.unauditedCVRIDsInRange(the_cdb, the_cdb.auditedPrefixLength(),
+          CVRAuditInfoQueries.unauditedCVRIDsInRange(the_cdb, round.startAuditedPrefixLength(),
                                                      round.expectedAuditedPrefixLength());
     }
     return result;
@@ -307,6 +307,7 @@ public final class ComparisonAuditController {
     }
     
     the_cdb.setAuditedPrefixLength(0);
+    the_cdb.setAuditedRecordCount(0);
     for (final CountyContestResult ccr : 
          CountyContestResultQueries.forCounty(the_cdb.county())) {
       AuditReason reason = contest_reasons.get(ccr.contest());
@@ -513,6 +514,7 @@ public final class ComparisonAuditController {
         the_cdb.addAuditedBallot();
         final Pair<Set<AuditReason>, Set<AuditReason>> audit_results = 
             audit(the_cdb, the_cvr_under_audit, the_audit_cvr, info.size(), true);
+        the_cdb.setAuditedRecordCount(the_cdb.auditedRecordCount() + info.size());
         for (final CVRAuditInfo c : info) {
           c.setACVR(the_audit_cvr);
           c.setCounted(true);
@@ -553,10 +555,10 @@ public final class ComparisonAuditController {
     updateCVRUnderAudit(the_cdb);
     the_cdb.
         setEstimatedBallotsToAudit(computeEstimatedBallotsToAudit(the_cdb) -
-                                   the_cdb.auditedPrefixLength());
+                                   the_cdb.auditedRecordCount());
     the_cdb.
         setOptimisticBallotsToAudit(computeOptimisticBallotsToAudit(the_cdb) -
-                                    the_cdb.auditedPrefixLength());
+                                    the_cdb.auditedRecordCount());
     return result;
   }
   
@@ -758,6 +760,7 @@ public final class ComparisonAuditController {
         cai.setDiscrepancy(audit_results.first());
         cai.setDisagreement(audit_results.second());
         Persistence.saveOrUpdate(cai);
+        the_cdb.setAuditedRecordCount(the_cdb.auditedRecordCount() + 1);
       }
       index = index + 1;
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/ContestJsonAdapter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/ContestJsonAdapter.java
@@ -88,7 +88,7 @@ public final class ContestJsonAdapter extends TypeAdapter<Contest> {
     the_writer.name(CHOICES);
     the_writer.beginArray();
     for (final Choice c : the_contest.choices()) {
-      if (!"Write-in".equals(c.name())) {
+      if (!c.fictitious()) {
         the_writer.jsonValue(Main.GSON.toJson(Persistence.unproxy(c)));
       }
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -443,7 +443,7 @@ public class CountyDashboardRefreshResponse {
                                               asm.currentState(),
                                               audit_board_asm.currentState(),
                                               null,
-                                              null,
+                                              the_dashboard.currentAuditBoard(),
                                               manifest_digest,
                                               the_dashboard.manifestUploadTimestamp(),
                                               manifest_filename,

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Choice.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Choice.java
@@ -43,6 +43,19 @@ public class Choice implements Serializable {
   private String my_description;
   
   /**
+   * A flag that indicates whether or not a choice is a qualified write-in.
+   */
+  private boolean my_qualified_write_in;
+  
+  /**
+   * A flag that indicates whether or not a choice is "fictitious" (i.e., whether
+   * its votes should be counted and it should be displayed). This is to
+   * handle cases where specific "fake" choice names are used to delineate
+   * sections of a ballot, as with Dominion and qualified write-ins.
+   */
+  private boolean my_fictitious;
+  
+  /**
    * Constructs a choice with default values, solely for persistence.
    */
   public Choice() {
@@ -54,10 +67,18 @@ public class Choice implements Serializable {
    * 
    * @param the_name The choice name.
    * @param the_description The choice description.
+   * @param the_qualified_write_in True if this choice is a qualified
+   * write-in candidate, false otherwise.
+   * @param the_fictitious True of this choice is fictitious (should not be
+   * counted), false otherwise.
    */
-  public Choice(final String the_name, final String the_description) {
+  public Choice(final String the_name, final String the_description,
+                final boolean the_qualified_write_in,
+                final boolean the_fictitious) {
     my_name = the_name;
     my_description = the_description;
+    my_qualified_write_in = the_qualified_write_in;
+    my_fictitious = the_fictitious;
   }
   
   /**
@@ -72,6 +93,20 @@ public class Choice implements Serializable {
    */
   public String description() {
     return my_description;
+  }
+  
+  /**
+   * @return true if this choice is a qualified write-in, false otherwise.
+   */
+  public boolean qualifiedWriteIn() {
+    return my_qualified_write_in;
+  }
+  
+  /**
+   * @return true if this choice is fictitious, false otherwise.
+   */
+  public boolean fictitious() {
+    return my_fictitious;
   }
   
   /**
@@ -96,6 +131,8 @@ public class Choice implements Serializable {
       final Choice other_choice = (Choice) the_other;
       result &= nullableEquals(other_choice.name(), name());
       result &= nullableEquals(other_choice.description(), description());
+      result &= nullableEquals(other_choice.qualifiedWriteIn(), qualifiedWriteIn());
+      result &= nullableEquals(other_choice.fictitious(), fictitious());
     } else {
       result = false;
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Contest.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Contest.java
@@ -244,7 +244,7 @@ public class Contest implements PersistentEntity, Serializable {
            my_description + ", choices=" + choices() + 
            ", votes_allowed=" + my_votes_allowed + "]";
   }
-
+  
   /**
    * Compare this object with another for equivalence.
    * 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
@@ -385,11 +385,11 @@ public class CountyContestComparisonAudit implements PersistentEntity, Serializa
       my_estimated_ballots_to_audit = my_optimistic_ballots_to_audit;
     } else {
       // compute the "fudge factor" for the estimate
-      final BigDecimal prefix_length = BigDecimal.valueOf(my_dashboard.auditedPrefixLength());
+      final BigDecimal audited_samples = BigDecimal.valueOf(my_dashboard.auditedSampleCount());
       final BigDecimal overstatements = 
           BigDecimal.valueOf(my_one_vote_over + my_two_vote_over);
       final BigDecimal fudge_factor =
-          BigDecimal.ONE.add(overstatements.divide(prefix_length, MathContext.DECIMAL128));
+          BigDecimal.ONE.add(overstatements.divide(audited_samples, MathContext.DECIMAL128));
       final BigDecimal estimated =
           BigDecimal.valueOf(my_optimistic_ballots_to_audit).multiply(fudge_factor);
       my_estimated_ballots_to_audit = estimated.setScale(0, RoundingMode.CEILING).intValue();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestResult.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestResult.java
@@ -185,7 +185,9 @@ public class CountyContestResult implements PersistentEntity, Serializable {
     my_contest = the_contest;
     my_votes_allowed = the_contest.votesAllowed();
     for (final Choice c : the_contest.choices()) {
-      my_vote_totals.put(c.name(), 0);
+      if (!c.fictitious()) {
+        my_vote_totals.put(c.name(), 0);
+      }
     }
   }
  

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -248,10 +248,9 @@ public class CountyDashboard implements PersistentEntity, Serializable {
   private Integer my_audited_prefix_length;
   
   /**
-   * The number of records in the audit sequence that have actually
-   * been audited so far.
+   * The number of samples that have been audited so far.
    */
-  private Integer my_audited_record_count;
+  private Integer my_audited_sample_count;
   
   /**
    * The number of discrepancies found in the audit so far.
@@ -873,21 +872,21 @@ public class CountyDashboard implements PersistentEntity, Serializable {
   }
 
   /**
-   * @return the number of audited records that have been counted in the
+   * @return the number of samples that have been included in the
    * audit calculations so far.
    */
-  public Integer auditedRecordCount() {
-    return my_audited_record_count;
+  public Integer auditedSampleCount() {
+    return my_audited_sample_count;
   }
   
   /**
-   * Sets the number of audited records that have been counted in the
+   * Sets the number of samples that have been included in the
    * audit calculations so far.
    * 
-   * @param the_audited_record_count The audited record count.
+   * @param the_audited_sample_count The audited sample count.
    */
-  public void setAuditedRecordCount(final int the_audited_record_count) {
-    my_audited_record_count = the_audited_record_count;
+  public void setAuditedSampleCount(final int the_audited_sample_count) {
+    my_audited_sample_count = the_audited_sample_count;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -248,6 +248,12 @@ public class CountyDashboard implements PersistentEntity, Serializable {
   private Integer my_audited_prefix_length;
   
   /**
+   * The number of records in the audit sequence that have actually
+   * been audited so far.
+   */
+  private Integer my_audited_record_count;
+  
+  /**
    * The number of discrepancies found in the audit so far.
    */
   @Column(nullable = false, name = "discrepancies", columnDefinition = "text")
@@ -865,6 +871,25 @@ public class CountyDashboard implements PersistentEntity, Serializable {
           setActualAuditedPrefixLength(the_audited_prefix_length);
     }
   }
+
+  /**
+   * @return the number of audited records that have been counted in the
+   * audit calculations so far.
+   */
+  public Integer auditedRecordCount() {
+    return my_audited_record_count;
+  }
+  
+  /**
+   * Sets the number of audited records that have been counted in the
+   * audit calculations so far.
+   * 
+   * @param the_audited_record_count The audited record count.
+   */
+  public void setAuditedRecordCount(final int the_audited_record_count) {
+    my_audited_record_count = the_audited_record_count;
+  }
+
   /**
    * @return a String representation of this contest.
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DoSDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DoSDashboard.java
@@ -179,21 +179,28 @@ public class DoSDashboard implements PersistentEntity, Serializable {
    * Update the audit status of a contest. 
    * 
    * @param the_contest_to_audit The new status of the contest to audit.
+   * @return true if the contest was already being audited or hand counted, 
+   * false otherwise.
    */
   //@ requires the_contest_to_audit != null;
-  public void updateContestToAudit(final ContestToAudit the_contest_to_audit) {
+  public boolean updateContestToAudit(final ContestToAudit the_contest_to_audit) {
+    boolean result = false;
+    
     // check to see if the contest is in our set
     final Set<ContestToAudit> contests_to_remove = new HashSet<>();
     for (final ContestToAudit c : my_contests_to_audit) {
       if (c.contest().equals(the_contest_to_audit.contest())) {
         // flag the entry for removal
         contests_to_remove.add(c);
+        result = true;
       }
     }
     my_contests_to_audit.removeAll(contests_to_remove);
     if (the_contest_to_audit.audit() != AuditType.NONE) {
       my_contests_to_audit.add(the_contest_to_audit);
     }
+    
+    return result;
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -390,9 +390,6 @@ public class CountyReport {
       cell.setCellValue("Diluted Margin %");
       
       for (final String choice : ccr.rankedChoices()) {
-        if ("Write-in".equals(choice)) {
-          continue;
-        }
         row = summary_sheet.createRow(row_number++);
         max_cell_number = Math.max(max_cell_number, cell_number);
         cell_number = 0;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
@@ -337,9 +337,6 @@ public class StateReport {
           cell.setCellValue("Diluted Margin %");
 
           for (final String choice : ccr.rankedChoices()) {
-            if ("Write-in".equals(choice)) {
-              continue;
-            }
             row = summary_sheet.createRow(row_number++);
             max_cell_number = Math.max(max_cell_number, cell_number);
             cell_number = 0;


### PR DESCRIPTION
Several features necessary for this week's deliverable (changes to Excel reports will follow tomorrow in a separate PR):

- counting of audited ballot discrepancies when they are reported instead of when the ballots come up in the audit sequence
- enabling of selection of contests for hand count
- sending audit board info to the DoS dashboard
- more robustly handles write-in candidates, including flagging qualified write-ins for potential future indication in the UI

Closes #743 (sort of)
Unblocks #742 
Closes #715 
Closes #696 
Closes #591 
