### PR TITLE
Attempt to fix ASM transitions for multi-transaction endpoints.

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -174,6 +174,10 @@ public abstract class AbstractEndpoint implements Endpoint {
       return true;
     }
     try {
+      // this asmFor() will be a no-op in nearly all cases, but in multi-transaction
+      // endpoint hits like uploading large CVR imports, it is possible for the
+      // state to change out from underneath us
+      my_asm.set(ASMUtilities.asmFor(asmClass(), my_asm.get().identity()));
       my_asm.get().stepEvent(endpointEvent());
     } catch (final IllegalStateException e) {
       illegalTransition(the_response, e.getMessage(), false);


### PR DESCRIPTION
Nearly all endpoints are transactional; CVR imports, however, are multi-transaction. As a result, if somebody imports a ballot manifest while a CVR is being imported, it may not be noticed. This is an attempt to address that.