### PR TITLE
Fix for DoS user not specifying a county in CVR downloads.

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -146,7 +146,10 @@ public class CVRToAuditDownload extends AbstractEndpoint {
           result &= r > 0;
         }
         
-        if (county != null) {
+        if (county == null && Main.authentication().authenticatedCounty(the_request) == null) {
+          // it's a DoS user, but they didn't specify a county
+          result = false;
+        } else if (county != null) {
           Long.parseLong(county);
         }
       } catch (final NumberFormatException e) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -123,7 +123,10 @@ public class CVRToAuditList extends AbstractEndpoint {
           result &= r > 0;
         }
         
-        if (county != null) {
+        if (county == null && Main.authentication().authenticatedCounty(the_request) == null) {
+          // it's a DoS user, but they didn't specify a county
+          result = false;
+        } else if (county != null) {
           Long.parseLong(county);
         }
       } catch (final NumberFormatException e) {


### PR DESCRIPTION
Currently this causes an uncaught error; it should cause parameters to not validate.