### PR TITLE
Final client changes

### DIFF
--- a/client/src/component/DOS/Contest/DetailPage.tsx
+++ b/client/src/component/DOS/Contest/DetailPage.tsx
@@ -51,7 +51,7 @@ const ContestDetailPage = (props: any) => {
 
     const row = (k: any, v: any) => (
         <tr key={ k } >
-            <td>{ k }</td>
+            <td><strong>{ k }</strong></td>
             <td>{ v }</td>
         </tr>
     );

--- a/client/src/component/DOS/Contest/DetailPage.tsx
+++ b/client/src/component/DOS/Contest/DetailPage.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 
 import * as _ from 'lodash';
 
+import counties from 'corla/data/counties';
+
 import Nav from '../Nav';
 
 
@@ -54,6 +56,8 @@ const ContestDetailPage = (props: any) => {
         </tr>
     );
 
+    const county = counties[contest.countyId];
+
     return (
         <div>
             <Nav />
@@ -63,7 +67,7 @@ const ContestDetailPage = (props: any) => {
                 <h3>Contest Data</h3>
                 <table className='pt-table pt-bordered pt-condensed'>
                     <tbody>
-                        { row('ID', contest.id) }
+                        { row('County', county.name) }
                         { row('Name', contest.name) }
                         { row('Description', contest.description) }
                         { row('Vote For', contest.votesAllowed) }

--- a/client/src/component/DOS/Contest/OverviewPage.tsx
+++ b/client/src/component/DOS/Contest/OverviewPage.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 
 import * as _ from 'lodash';
 
+import counties from 'corla/data/counties';
+
 import Nav from '../Nav';
 
 
@@ -24,18 +26,22 @@ const Breadcrumb = () => (
     </ul>
 );
 
-const ContestTableRow = ({ contest }: any) => (
-    <tr>
-        <td>{ contest.id }</td>
-        <td>
-            <Link to={ `/sos/contest/${contest.id}` }>
-                { contest.name }
-            </Link>
-        </td>
-        <td>{ contest.choices.length }</td>
-        <td>{ contest.votesAllowed }</td>
-    </tr>
-);
+const ContestTableRow = ({ contest }: any) => {
+    const county = counties[contest.countyId];
+
+    return (
+        <tr>
+            <td>{ county.name }</td>
+            <td>
+                <Link to={ `/sos/contest/${contest.id}` }>
+                    { contest.name }
+                </Link>
+            </td>
+            <td>{ contest.choices.length }</td>
+            <td>{ contest.votesAllowed }</td>
+        </tr>
+    );
+};
 
 const ContestTable = ({ contests }: any) => {
     const contestRows = _.map(contests, (c: any) => (
@@ -46,7 +52,7 @@ const ContestTable = ({ contests }: any) => {
         <table className='pt-table pt-bordered pt-condensed'>
             <thead>
                 <tr>
-                    <td>ID</td>
+                    <td>County</td>
                     <td>Name</td>
                     <td>Choices</td>
                     <td>Vote For</td>

--- a/client/src/component/DOS/Contest/OverviewPage.tsx
+++ b/client/src/component/DOS/Contest/OverviewPage.tsx
@@ -52,10 +52,10 @@ const ContestTable = ({ contests }: any) => {
         <table className='pt-table pt-bordered pt-condensed'>
             <thead>
                 <tr>
-                    <td>County</td>
-                    <td>Name</td>
-                    <td>Choices</td>
-                    <td>Vote For</td>
+                    <th>County</th>
+                    <th>Name</th>
+                    <th>Choices</th>
+                    <th>Vote For</th>
                 </tr>
             </thead>
             <tbody>

--- a/client/src/component/DOS/DefineAudit/ElectionTypeForm.tsx
+++ b/client/src/component/DOS/DefineAudit/ElectionTypeForm.tsx
@@ -45,7 +45,7 @@ class ElectionTypeForm extends React.Component<any, FormState> {
     private onFormChange = (e: React.ChangeEvent<any>) => {
         const type = e.target.value;
 
-        this.props.setFormValid(!!type);
+        this.props.setFormValid({ type: !!type });
 
         this.setState({ type });
     }

--- a/client/src/component/DOS/DefineAudit/RiskLimitForm.tsx
+++ b/client/src/component/DOS/DefineAudit/RiskLimitForm.tsx
@@ -137,6 +137,11 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         s.comparisonField = field;
 
         this.setState(s);
+
+        // Tell parent component if it should disable the "Save" button.
+        const parsedComparisonField = parseFloat(s.comparisonField);
+        const fieldValid = isValidRiskLimit(parsedComparisonField);
+        this.props.setFormValid({ riskLimit: fieldValid });
     }
 }
 

--- a/client/src/component/DOS/DefineAudit/RiskLimitForm.tsx
+++ b/client/src/component/DOS/DefineAudit/RiskLimitForm.tsx
@@ -101,6 +101,7 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         s.comparisonLimit = fromPercent(parsedComparisonField);
 
         this.setState(s);
+        this.syncParent();
     }
 
     private onBlur = () => {
@@ -121,6 +122,7 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         }
 
         this.setState(s);
+        this.syncParent();
     }
 
     private onBallotPollingValueChange = (_: number, field: string) => {
@@ -129,6 +131,7 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         s.ballotPollingField = field;
 
         this.setState(s);
+        this.syncParent();
     }
 
     private onComparisonValueChange = (_: number, field: string) => {
@@ -137,9 +140,12 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         s.comparisonField = field;
 
         this.setState(s);
+        this.syncParent();
+    }
 
+    private syncParent = () => {
         // Tell parent component if it should disable the "Save" button.
-        const parsedComparisonField = parseFloat(s.comparisonField);
+        const parsedComparisonField = parseFloat(this.state.comparisonField);
         const fieldValid = isValidRiskLimit(parsedComparisonField);
         this.props.setFormValid({ riskLimit: fieldValid });
     }

--- a/client/src/component/DOS/DefineAudit/RiskLimitForm.tsx
+++ b/client/src/component/DOS/DefineAudit/RiskLimitForm.tsx
@@ -101,7 +101,7 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         s.comparisonLimit = fromPercent(parsedComparisonField);
 
         this.setState(s);
-        this.syncParent();
+        this.syncParent(s);
     }
 
     private onBlur = () => {
@@ -122,7 +122,7 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         }
 
         this.setState(s);
-        this.syncParent();
+        this.syncParent(s);
     }
 
     private onBallotPollingValueChange = (_: number, field: string) => {
@@ -131,7 +131,7 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         s.ballotPollingField = field;
 
         this.setState(s);
-        this.syncParent();
+        this.syncParent(s);
     }
 
     private onComparisonValueChange = (_: number, field: string) => {
@@ -140,12 +140,12 @@ class RiskLimitForm extends React.Component<FormProps & any, FormState> {
         s.comparisonField = field;
 
         this.setState(s);
-        this.syncParent();
+        this.syncParent(s);
     }
 
-    private syncParent = () => {
+    private syncParent = (s: any) => {
         // Tell parent component if it should disable the "Save" button.
-        const parsedComparisonField = parseFloat(this.state.comparisonField);
+        const parsedComparisonField = parseFloat(s.comparisonField);
         const fieldValid = isValidRiskLimit(parsedComparisonField);
         this.props.setFormValid({ riskLimit: fieldValid });
     }

--- a/client/src/component/DOS/DefineAudit/StartPage.tsx
+++ b/client/src/component/DOS/DefineAudit/StartPage.tsx
@@ -171,7 +171,9 @@ const AuditPage = (props: any) => {
                 <div>
                     Enter the risk limit for comparison audits as a percentage.
                 </div>
-                <RiskLimitForm forms={ forms } riskLimit={ riskLimit } />
+                <RiskLimitForm forms={ forms }
+                               riskLimit={ riskLimit }
+                               setFormValid={ setFormValid } />
                 <div className='pt-card'>
                     <span className='pt-icon pt-intent-warning pt-icon-warning-sign' />
                     <span> </span>

--- a/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
@@ -9,6 +9,7 @@ import withSync from 'corla/component/withSync';
 
 class StartPageContainer extends React.Component<any, any> {
     public state: any = {
+        riskLimit: false,
         type: true,
     };
 
@@ -36,7 +37,7 @@ class StartPageContainer extends React.Component<any, any> {
     }
 
     private formIsValid = () => {
-        return !!this.state.type;
+        return this.state.riskLimit && this.state.type;
     }
 
     private setFormValid = (s: any) => {

--- a/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
@@ -9,7 +9,7 @@ import withSync from 'corla/component/withSync';
 
 class StartPageContainer extends React.Component<any, any> {
     public state: any = {
-        formValid: false,
+        type: true,
     };
 
     public render() {
@@ -25,7 +25,7 @@ class StartPageContainer extends React.Component<any, any> {
 
         const props = {
             election,
-            formValid: this.state.formValid,
+            formValid: this.formIsValid(),
             nextPage: () => history.push('/sos/audit/select-contests'),
             publicMeetingDate,
             riskLimit,
@@ -35,8 +35,12 @@ class StartPageContainer extends React.Component<any, any> {
         return <StartPage { ...props } />;
     }
 
-    private setFormValid = (formValid: boolean) => {
-        this.setState({ formValid });
+    private formIsValid = () => {
+        return !!this.state.type;
+    }
+
+    private setFormValid = (s: any) => {
+        this.setState(s);
     }
 }
 

--- a/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
@@ -9,8 +9,8 @@ import withSync from 'corla/component/withSync';
 
 class StartPageContainer extends React.Component<any, any> {
     public state: any = {
-        riskLimit: false,
-        type: true,
+        riskLimit: true,
+        type: false,
     };
 
     public render() {


### PR DESCRIPTION
This ensures we show the county associated with each contest in the DOS contest overview and detail pages. It also fixes #762 by ensuring that, when defining an audit, the user cannot attempt to save the risk limit value unless the _visible_ risk limit is valid.