### PR TITLE
Display error message on login failure

### DIFF
--- a/client/src/saga/logoutSaga.ts
+++ b/client/src/saga/logoutSaga.ts
@@ -5,7 +5,10 @@ import session from 'corla/session';
 
 function* logoutRedirect(): IterableIterator<void> {
     session.expire();
-    window.location.replace('/login');
+
+    if (window.location.pathname !== '/login') {
+        window.location.replace('/login');
+    }
 }
 
 


### PR DESCRIPTION
Due to some other authorization-related redirects that weere added,
when login failed, we were setting `window.location` to `/login`, even
when we were already there. This presented as a page refresh which
would win a race with notification display, hiding the error message.