### PR TITLE
Change the way discrepancies and disagreement totals are reported

### DIFF
--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>us.freeandfair.production</groupId>
 	<artifactId>colorado_rla</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<name>ColoradoRLA</name>
 	<description>A risk-limiting audit system for the State of Colorado</description>
 	<properties>
@@ -197,6 +197,11 @@
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-core</artifactId>
 			<version>3.1.12</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-model</artifactId>
+			<version>3.5.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -31,6 +32,9 @@ import javax.persistence.PersistenceException;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Server;
 
@@ -138,7 +142,12 @@ public final class Main {
       setFieldNamingStrategy(new FreeAndFairNamingStrategy()).
       setExclusionStrategies(new VersionExclusionStrategy()).
       setPrettyPrinting().create();
-
+  
+  /**
+   * The version string.
+   */
+  public static final String VERSION;
+  
   /**
    * Which authentication subsystem implementation are we to use?
    */
@@ -148,6 +157,21 @@ public final class Main {
    * The properties loaded from the properties file.
    */
   private final Properties my_properties;
+  
+  // Version Initializer
+  
+  static {
+    String version = "UNKNOWN";
+    try (InputStreamReader isr = 
+         new InputStreamReader(new FileInputStream("pom.xml"), "UTF-8")) {
+      final MavenXpp3Reader reader = new MavenXpp3Reader();
+      final Model model = reader.read(isr);
+      version = model.getVersion();
+    } catch (final IOException | XmlPullParserException e) {
+      // version is already set to "UNKNOWN"
+    }
+    VERSION = version;
+  }
   
   // Constructors
 
@@ -161,6 +185,13 @@ public final class Main {
   }
   
   // Instance Methods
+  
+  /**
+   * @return the version string of the system.
+   */
+  public static String version() {
+    return VERSION;
+  }
   
   /**
    * @return the implementation of `AuthenticationInterface` demanded by
@@ -414,7 +445,7 @@ public final class Main {
    * Starts a ColoradoRLA server.
    */
   public void start() {
-    LOGGER.info("starting server with properties: " + my_properties);
+    LOGGER.info("starting server version " + VERSION + " with properties: " + my_properties);
 
     // provide properties to the persistence engine
     Persistence.setProperties(my_properties);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -674,13 +674,8 @@ public final class ComparisonAuditController {
     }
     
     if (the_update_counters) {
-      for (final AuditReason r : discrepancies) {
-        the_cdb.addDiscrepancy(r);
-      }
-      
-      for (final AuditReason r : disagreements) {
-        the_cdb.addDisagreement(r);
-      }
+      the_cdb.addDiscrepancy(discrepancies);
+      the_cdb.addDisagreement(disagreements);
     }
   }
   
@@ -734,13 +729,8 @@ public final class ComparisonAuditController {
       Persistence.saveOrUpdate(cvrai);
     }
     
-    for (final AuditReason r : discrepancies) {
-      the_cdb.removeDiscrepancy(r);
-    }
-    
-    for (final AuditReason r : disagreements) {
-      the_cdb.removeDiscrepancy(r);
-    }
+    the_cdb.removeDiscrepancy(discrepancies);
+    the_cdb.removeDisagreement(disagreements);
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
@@ -573,7 +573,8 @@ public class DominionCVRExportParser implements CVRExportParser {
           } else {
             my_record_count = my_record_count + 1;
             if (my_record_count % PROGRESS_INTERVAL == 0) {
-              Main.LOGGER.info("parsed " + my_record_count + " CVRs");
+              Main.LOGGER.info("parsed " + my_record_count + 
+                               " CVRs for county " + my_county.id());
             }
           }
         }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
@@ -14,6 +14,8 @@ package us.freeandfair.corla.endpoint;
 import spark.Request;
 import spark.Response;
 
+import us.freeandfair.corla.Main;
+
 /**
  * The root endpoint.
  * 
@@ -43,7 +45,7 @@ public class Root extends AbstractEndpoint {
    */
   @Override
   public String endpoint(final Request the_request, final Response the_response) {
-    ok(the_response, "ColoradoRLA Server, Version 1.0.0-beta-1 - " +
+    ok(the_response, "ColoradoRLA Server, Version " + Main.VERSION + " - " +
                      "Please Use a Valid Endpoint!");
     return my_endpoint_result.get();
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -28,7 +28,7 @@ import us.freeandfair.corla.asm.AuditBoardDashboardASM;
 import us.freeandfair.corla.asm.CountyDashboardASM;
 import us.freeandfair.corla.model.AuditBoard;
 import us.freeandfair.corla.model.AuditInfo;
-import us.freeandfair.corla.model.AuditReason;
+import us.freeandfair.corla.model.AuditSelection;
 import us.freeandfair.corla.model.AuditType;
 import us.freeandfair.corla.model.Contest;
 import us.freeandfair.corla.model.ContestToAudit;
@@ -135,14 +135,14 @@ public class CountyDashboardRefreshResponse {
   private final Integer my_audited_ballot_count;
   
   /**
-   * The numbers of discrepancies found, mapped by audit reason.
+   * The numbers of discrepancies found, mapped by audit selection.
    */
-  private final Map<AuditReason, Integer> my_discrepancy_count;
+  private final Map<AuditSelection, Integer> my_discrepancy_count;
   
   /**
-   * The number of disagreements found, mapped by audit reason.
+   * The number of disagreements found, mapped by audit selection.
    */
-  private final Map<AuditReason, Integer> my_disagreement_count;
+  private final Map<AuditSelection, Integer> my_disagreement_count;
 
   /**
    * The current ballot under audit.
@@ -223,9 +223,9 @@ public class CountyDashboardRefreshResponse {
                                            final Integer the_ballot_manifest_count,
                                            final Integer the_cvr_export_count,
                                            final Integer the_audited_ballot_count,
-                                           final Map<AuditReason, Integer> 
+                                           final Map<AuditSelection, Integer> 
                                                the_discrepancy_count, 
-                                           final Map<AuditReason, Integer> 
+                                           final Map<AuditSelection, Integer> 
                                                the_disagreement_count,
                                            final Long the_ballot_under_audit_id,
                                            final Integer the_audited_prefix_length,

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/AuditSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/AuditSelection.java
@@ -17,15 +17,9 @@ package us.freeandfair.corla.model;
  * @author Daniel M. Zimmerman <dmz@freeandfair.us>
  * @version 1.0.0
  */
-public enum AuditReason {
-  STATE_WIDE_CONTEST("Statewide Contest"),
-  COUNTY_WIDE_CONTEST("Countywide Contest"),
-  CLOSE_CONTEST("Close Contest"),
-  TIED_CONTEST("Tied Contest"),
-  GEOGRAPHICAL_SCOPE("Geographical Scope"),
-  CONCERN_REGARDING_ACCURACY("Concern Regarding Accuracy"),
-  OPPORTUNISTIC_BENEFITS("Opportunistic Benefits"),
-  COUNTY_CLERK_ABILITY("County Clerk Ability");
+public enum AuditSelection {
+  AUDITED_CONTEST("Audited Contest"),
+  UNAUDITED_CONTEST("Unaudited Contest");
 
   /**
    * The pretty printing string for this enum value.
@@ -37,7 +31,7 @@ public enum AuditReason {
    * 
    * @param the_pretty_string The pretty printing string.
    */
-  AuditReason(final String the_pretty_string) {
+  AuditSelection(final String the_pretty_string) {
     my_pretty_string = the_pretty_string;
   }
   
@@ -46,16 +40,5 @@ public enum AuditReason {
    */
   public String prettyString() {
     return my_pretty_string;
-  }
-  
-  /**
-   * @return the audit selection corresponding to this audit reason.
-   */
-  public AuditSelection selection() {
-    if (this.equals(TIED_CONTEST) || this.equals(OPPORTUNISTIC_BENEFITS)) {
-      return AuditSelection.UNAUDITED_CONTEST;
-    } else {
-      return AuditSelection.AUDITED_CONTEST;
-    }
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -724,20 +724,7 @@ public class CountyDashboard implements PersistentEntity {
   public void setBallotsInManifest(final Integer the_ballots_in_manifest) {
     my_ballots_in_manifest = the_ballots_in_manifest;
   }
-  
-  /**
-   * Ensures that a counter exists in the specified map for the specified key.
-   * 
-   * @param the_map The map.
-   * @param the_key The key.
-   */
-  private void ensureCounterExists(final Map<AuditSelection, Integer> the_map,
-                                   final AuditSelection the_key) {
-    if (!the_map.containsKey(the_key)) {
-      the_map.put(the_key, 0);
-    }
-  }
-  
+
   /**
    * @return the numbers of discrepancies found in the audit so far, 
    * categorized by contest audit selection.
@@ -758,8 +745,7 @@ public class CountyDashboard implements PersistentEntity {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_discrepancies, s);
-      my_discrepancies.put(s, my_discrepancies.get(s) + 1);
+      my_discrepancies.put(s, my_discrepancies.getOrDefault(s, 0) + 1);
     }
     if (my_current_round_index != null) {
       my_rounds.get(my_current_round_index).addDiscrepancy(the_reasons);
@@ -779,8 +765,7 @@ public class CountyDashboard implements PersistentEntity {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_discrepancies, s);
-      my_discrepancies.put(s, my_discrepancies.get(s) - 1);
+      my_discrepancies.put(s, my_discrepancies.getOrDefault(s, 0) - 1);
     }
     if (my_current_round_index != null) {
       my_rounds.get(my_current_round_index).removeDiscrepancy(the_reasons);
@@ -808,8 +793,7 @@ public class CountyDashboard implements PersistentEntity {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_disagreements, s);
-      my_disagreements.put(s, my_disagreements.get(s) + 1);
+      my_disagreements.put(s, my_disagreements.getOrDefault(s, 0) + 1);
     }
     if (my_current_round_index != null) {
       my_rounds.get(my_current_round_index).addDisagreement(the_reasons);
@@ -829,8 +813,7 @@ public class CountyDashboard implements PersistentEntity {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_disagreements, s);
-      my_disagreements.put(s, my_disagreements.get(s) - 1);
+      my_disagreements.put(s, my_disagreements.getOrDefault(s, 0) - 1);
     }
     if (my_current_round_index != null) {
       my_rounds.get(my_current_round_index).removeDisagreement(the_reasons);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -43,7 +43,7 @@ import javax.persistence.Table;
 import javax.persistence.Version;
 
 import us.freeandfair.corla.model.CVRContestInfo.ConsensusValue;
-import us.freeandfair.corla.persistence.AuditReasonIntegerMapConverter;
+import us.freeandfair.corla.persistence.AuditSelectionIntegerMapConverter;
 import us.freeandfair.corla.persistence.PersistentEntity;
 
 /**
@@ -255,15 +255,15 @@ public class CountyDashboard implements PersistentEntity {
    * The number of discrepancies found in the audit so far.
    */
   @Column(nullable = false, name = "discrepancies", columnDefinition = "text")
-  @Convert(converter = AuditReasonIntegerMapConverter.class)
-  private Map<AuditReason, Integer> my_discrepancies = new HashMap<>();
+  @Convert(converter = AuditSelectionIntegerMapConverter.class)
+  private Map<AuditSelection, Integer> my_discrepancies = new HashMap<>();
   
   /**
    * The number of disagreements found in the audit so far.
    */
   @Column(nullable = false, name = "disagreements", columnDefinition = "text")
-  @Convert(converter = AuditReasonIntegerMapConverter.class)
-  private Map<AuditReason, Integer> my_disagreements = new HashMap<>();
+  @Convert(converter = AuditSelectionIntegerMapConverter.class)
+  private Map<AuditSelection, Integer> my_disagreements = new HashMap<>();
   
   /**
    * Constructs an empty county dashboard, solely for persistence.
@@ -533,12 +533,8 @@ public class CountyDashboard implements PersistentEntity {
         }
       }
       the_round.addAuditedBallot();
-      for (final AuditReason r : discrepancies) {
-        the_round.addDiscrepancy(r);
-      }
-      for (final AuditReason r : disagreements) {
-        the_round.addDisagreement(r);
-      }
+      the_round.addDiscrepancy(discrepancies);
+      the_round.addDisagreement(disagreements);
       index = index + 1;
     }
   }
@@ -735,8 +731,8 @@ public class CountyDashboard implements PersistentEntity {
    * @param the_map The map.
    * @param the_key The key.
    */
-  private void ensureCounterExists(final Map<AuditReason, Integer> the_map,
-                                   final AuditReason the_key) {
+  private void ensureCounterExists(final Map<AuditSelection, Integer> the_map,
+                                   final AuditSelection the_key) {
     if (!the_map.containsKey(the_key)) {
       the_map.put(the_key, 0);
     }
@@ -744,73 +740,100 @@ public class CountyDashboard implements PersistentEntity {
   
   /**
    * @return the numbers of discrepancies found in the audit so far, 
-   * categorized by contest audit reason.
+   * categorized by contest audit selection.
    */
-  public Map<AuditReason, Integer> discrepancies() {
+  public Map<AuditSelection, Integer> discrepancies() {
     return Collections.unmodifiableMap(my_discrepancies);
   }
   
   /**
-   * Adds a discrepancy for the specified audit reason. This adds it both to the 
+   * Adds a discrepancy for the specified audit reasons. This adds it both to the 
    * total and to the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * @param the_reasons The reasons.
    */
-  public void addDiscrepancy(final AuditReason the_reason) {
-    ensureCounterExists(my_discrepancies, the_reason);
-    my_discrepancies.put(the_reason, my_discrepancies.get(the_reason) + 1); 
+  public void addDiscrepancy(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
+    }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_discrepancies, s);
+      my_discrepancies.put(s, my_discrepancies.get(s) + 1);
+    }
     if (my_current_round_index != null) {
-      my_rounds.get(my_current_round_index).addDiscrepancy(the_reason);
+      my_rounds.get(my_current_round_index).addDiscrepancy(the_reasons);
     } 
   }
   
   /**
-   * Removes a discrepancy for the specified audit reason. This removes it 
+   * Removes a discrepancy for the specified audit reasons. This removes it 
    * both from the total and from the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * 
+   * @param the_reasons The reasons.
    */
-  public void removeDiscrepancy(final AuditReason the_reason) {
-    ensureCounterExists(my_discrepancies, the_reason);
-    my_discrepancies.put(the_reason, my_discrepancies.get(the_reason) - 1);
-    if (my_current_round_index != null) {
-      my_rounds.get(my_current_round_index).removeDiscrepancy(the_reason);
+  public void removeDiscrepancy(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
     }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_discrepancies, s);
+      my_discrepancies.put(s, my_discrepancies.get(s) - 1);
+    }
+    if (my_current_round_index != null) {
+      my_rounds.get(my_current_round_index).removeDiscrepancy(the_reasons);
+    } 
   }
+  
   
   /**
    * @return the numbers of disagreements found in the audit so far,
-   * categorized by contest audit reason.
+   * categorized by contest audit selection.
    */
-  public Map<AuditReason, Integer> disagreements() {
+  public Map<AuditSelection, Integer> disagreements() {
     return my_disagreements;
   }
   
   /**
-   * Adds a disagreement for the specified audit reason. This adds it both to the 
+   * Adds a disagreement for the specified audit reasons. This adds it both to the 
    * total and to the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * @param the_reasons The reasons.
    */
-  public void addDisagreement(final AuditReason the_reason) {
-    ensureCounterExists(my_disagreements, the_reason);
-    my_disagreements.put(the_reason, my_disagreements.get(the_reason) + 1);
+  public void addDisagreement(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
+    }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_disagreements, s);
+      my_disagreements.put(s, my_disagreements.get(s) + 1);
+    }
     if (my_current_round_index != null) {
-      my_rounds.get(my_current_round_index).addDisagreement(the_reason);
+      my_rounds.get(my_current_round_index).addDisagreement(the_reasons);
     } 
   }
   
   /**
-   * Removes a disagreement for the specified audit reason. This removes it 
+   * Removes a disagreement for the specified audit reasons. This removes it 
    * both from the total and from the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * 
+   * @param the_reasons The reasons.
    */
-  public void removeDisagreement(final AuditReason the_reason) {
-    ensureCounterExists(my_disagreements, the_reason);
-    my_disagreements.put(the_reason, my_disagreements.get(the_reason) - 1);
+  public void removeDisagreement(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
+    }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_disagreements, s);
+      my_disagreements.put(s, my_disagreements.get(s) - 1);
+    }
     if (my_current_round_index != null) {
-      my_rounds.get(my_current_round_index).removeDisagreement(the_reason);
+      my_rounds.get(my_current_round_index).removeDisagreement(the_reasons);
     } 
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -260,19 +260,6 @@ public class Round implements Serializable {
   }
   
   /**
-   * Ensures that a counter exists in the specified map for the specified key.
-   * 
-   * @param the_map The map.
-   * @param the_key The key.
-   */
-  private void ensureCounterExists(final Map<AuditSelection, Integer> the_map,
-                                   final AuditSelection the_key) {
-    if (!the_map.containsKey(the_key)) {
-      the_map.put(the_key, 0);
-    }
-  }
-  
-  /**
    * @return the numbers of discrepancies found in the audit so far, 
    * categorized by contest audit selection.
    */
@@ -292,8 +279,7 @@ public class Round implements Serializable {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_discrepancies, s);
-      my_discrepancies.put(s, my_discrepancies.get(s) + 1);
+      my_discrepancies.put(s, my_discrepancies.getOrDefault(s, 0) + 1);
     }
   }
   
@@ -309,8 +295,7 @@ public class Round implements Serializable {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_discrepancies, s);
-      my_discrepancies.put(s, my_discrepancies.get(s) - 1);
+      my_discrepancies.put(s, my_discrepancies.getOrDefault(s, 0) - 1);
     }
   }
   
@@ -334,8 +319,7 @@ public class Round implements Serializable {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_disagreements, s);
-      my_disagreements.put(s, my_disagreements.get(s) + 1);
+      my_disagreements.put(s, my_disagreements.getOrDefault(s, 0) + 1);
     }
   }
   
@@ -351,8 +335,7 @@ public class Round implements Serializable {
       selections.add(r.selection());
     }
     for (final AuditSelection s : selections) {
-      ensureCounterExists(my_disagreements, s);
-      my_disagreements.put(s, my_disagreements.get(s) - 1);
+      my_disagreements.put(s, my_disagreements.getOrDefault(s, 0) - 1);
     }
   }
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -19,14 +19,16 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Embeddable;
 
-import us.freeandfair.corla.persistence.AuditReasonIntegerMapConverter;
+import us.freeandfair.corla.persistence.AuditSelectionIntegerMapConverter;
 import us.freeandfair.corla.persistence.ElectorListConverter;
 
 /**
@@ -101,15 +103,15 @@ public class Round implements Serializable {
    * The number of discrepancies found in the audit so far.
    */
   @Column(nullable = false, name = "discrepancies", columnDefinition = "text")
-  @Convert(converter = AuditReasonIntegerMapConverter.class)
-  private Map<AuditReason, Integer> my_discrepancies = new HashMap<>();
+  @Convert(converter = AuditSelectionIntegerMapConverter.class)
+  private Map<AuditSelection, Integer> my_discrepancies = new HashMap<>();
   
   /**
    * The number of disagreements found in the audit so far.
    */
   @Column(nullable = false, name = "disagreements", columnDefinition = "text")
-  @Convert(converter = AuditReasonIntegerMapConverter.class)
-  private Map<AuditReason, Integer> my_disagreements = new HashMap<>();
+  @Convert(converter = AuditSelectionIntegerMapConverter.class)
+  private Map<AuditSelection, Integer> my_disagreements = new HashMap<>();
   
   /**
    * The signatories for round sign-off
@@ -263,8 +265,8 @@ public class Round implements Serializable {
    * @param the_map The map.
    * @param the_key The key.
    */
-  private void ensureCounterExists(final Map<AuditReason, Integer> the_map,
-                                   final AuditReason the_key) {
+  private void ensureCounterExists(final Map<AuditSelection, Integer> the_map,
+                                   final AuditSelection the_key) {
     if (!the_map.containsKey(the_key)) {
       the_map.put(the_key, 0);
     }
@@ -272,62 +274,86 @@ public class Round implements Serializable {
   
   /**
    * @return the numbers of discrepancies found in the audit so far, 
-   * categorized by contest audit reason.
+   * categorized by contest audit selection.
    */
-  public Map<AuditReason, Integer> discrepancies() {
+  public Map<AuditSelection, Integer> discrepancies() {
     return Collections.unmodifiableMap(my_discrepancies);
   }
   
   /**
-   * Adds a discrepancy for the specified audit reason. This adds it both to the 
+   * Adds a discrepancy for the specified audit reasons. This adds it both to the 
    * total and to the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * @param the_reasons The reasons.
    */
-  public void addDiscrepancy(final AuditReason the_reason) {
-    ensureCounterExists(my_discrepancies, the_reason);
-    my_discrepancies.put(the_reason, my_discrepancies.get(the_reason) + 1); 
+  public void addDiscrepancy(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
+    }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_discrepancies, s);
+      my_discrepancies.put(s, my_discrepancies.get(s) + 1);
+    }
   }
   
   /**
-   * Removes a discrepancy for the specified audit reason. This removes it 
+   * Removes a discrepancy for the specified audit reasons. This removes it 
    * both from the total and from the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * @param the_reasons The reasons.
    */
-  public void removeDiscrepancy(final AuditReason the_reason) {
-    ensureCounterExists(my_discrepancies, the_reason);
-    my_discrepancies.put(the_reason, my_discrepancies.get(the_reason) - 1);
+  public void removeDiscrepancy(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
+    }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_discrepancies, s);
+      my_discrepancies.put(s, my_discrepancies.get(s) - 1);
+    }
   }
   
   /**
    * @return the numbers of disagreements found in the audit so far,
    * categorized by contest audit reason.
    */
-  public Map<AuditReason, Integer> disagreements() {
+  public Map<AuditSelection, Integer> disagreements() {
     return my_disagreements;
   }
   
   /**
-   * Adds a disagreement for the specified audit reason. This adds it both to the 
+   * Adds a disagreement for the specified audit reasons. This adds it both to the 
    * total and to the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * @param the_reasons The reasons.
    */
-  public void addDisagreement(final AuditReason the_reason) {
-    ensureCounterExists(my_disagreements, the_reason);
-    my_disagreements.put(the_reason, my_disagreements.get(the_reason) + 1);
+  public void addDisagreement(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
+    }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_disagreements, s);
+      my_disagreements.put(s, my_disagreements.get(s) + 1);
+    }
   }
   
   /**
-   * Removes a disagreement for the specified audit reason. This removes it 
+   * Removes a disagreement for the specified audit reasons. This removes it 
    * both from the total and from the current audit round, if one is ongoing.
    * 
-   * @param the_reason The reason.
+   * @param the_reasons The reasons.
    */
-  public void removeDisagreement(final AuditReason the_reason) {
-    ensureCounterExists(my_disagreements, the_reason);
-    my_disagreements.put(the_reason, my_disagreements.get(the_reason) - 1);
+  public void removeDisagreement(final Set<AuditReason> the_reasons) {
+    final Set<AuditSelection> selections = new HashSet<>();
+    for (final AuditReason r : the_reasons) {
+      selections.add(r.selection());
+    }
+    for (final AuditSelection s : selections) {
+      ensureCounterExists(my_disagreements, s);
+      my_disagreements.put(s, my_disagreements.get(s) - 1);
+    }
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/AuditSelectionIntegerMapConverter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/AuditSelectionIntegerMapConverter.java
@@ -21,7 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
-import us.freeandfair.corla.model.AuditReason;
+import us.freeandfair.corla.model.AuditSelection;
 
 /**
  * A converter between maps from audit reasons to integers and JSON 
@@ -32,13 +32,13 @@ import us.freeandfair.corla.model.AuditReason;
  */
 @Converter
 @SuppressWarnings("PMD.AtLeastOneConstructor")
-public class AuditReasonIntegerMapConverter 
-    implements AttributeConverter<Map<AuditReason, Integer>, String> {
+public class AuditSelectionIntegerMapConverter 
+    implements AttributeConverter<Map<AuditSelection, Integer>, String> {
   /**
-   * The type information for a map from AuditReason to Integer.
+   * The type information for a map from AuditSelection to Integer.
    */
-  private static final Type AUDIT_REASON_INTEGER_MAP = 
-      new TypeToken<Map<AuditReason, Integer>>() { }.getType();
+  private static final Type AUDIT_SELECTION_INTEGER_MAP = 
+      new TypeToken<Map<AuditSelection, Integer>>() { }.getType();
   
   /**
    * Our Gson instance, which does not do pretty-printing (unlike the global
@@ -53,7 +53,7 @@ public class AuditReasonIntegerMapConverter
    * @param the_set The list of Strings.
    */
   @Override
-  public String convertToDatabaseColumn(final Map<AuditReason, Integer> the_map) {
+  public String convertToDatabaseColumn(final Map<AuditSelection, Integer> the_map) {
     return GSON.toJson(the_map); 
   }
 
@@ -63,7 +63,7 @@ public class AuditReasonIntegerMapConverter
    * @param the_column The column entry.
    */
   @Override
-  public Map<AuditReason, Integer> convertToEntityAttribute(final String the_column) {
-    return GSON.fromJson(the_column, AUDIT_REASON_INTEGER_MAP);
+  public Map<AuditSelection, Integer> convertToEntityAttribute(final String the_column) {
+    return GSON.fromJson(the_column, AUDIT_SELECTION_INTEGER_MAP);
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -480,7 +480,7 @@ public class CountyReport {
         cell.setCellType(CellType.NUMERIC);
         final int disagreements;
         if (round.disagreements().containsKey(AuditSelection.AUDITED_CONTEST)) {
-          disagreements = round.discrepancies().get(AuditSelection.AUDITED_CONTEST);
+          disagreements = round.disagreements().get(AuditSelection.AUDITED_CONTEST);
         } else {
           disagreements = 0;
         }
@@ -505,7 +505,7 @@ public class CountyReport {
         cell.setCellType(CellType.NUMERIC);
         final int disagreements;
         if (round.disagreements().containsKey(AuditSelection.UNAUDITED_CONTEST)) {
-          disagreements = round.discrepancies().get(AuditSelection.UNAUDITED_CONTEST);
+          disagreements = round.disagreements().get(AuditSelection.UNAUDITED_CONTEST);
         } else {
           disagreements = 0;
         }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.OptionalInt;
 
 import org.apache.poi.ss.usermodel.BorderStyle;
@@ -44,7 +43,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import us.freeandfair.corla.controller.ComparisonAuditController;
-import us.freeandfair.corla.model.AuditReason;
+import us.freeandfair.corla.model.AuditSelection;
 import us.freeandfair.corla.model.CVRAuditInfo;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
 import us.freeandfair.corla.model.County;
@@ -429,11 +428,11 @@ public class CountyReport {
         cell = row.createCell(cell_number++);
         cell.setCellStyle(integer_style);
         cell.setCellType(CellType.NUMERIC);
-        int discrepancies = 0;
-        for (final Entry<AuditReason, Integer> entry : round.discrepancies().entrySet()) {
-          if (entry.getKey().isAudited() && entry.getValue() != null) {
-            discrepancies = discrepancies + entry.getValue();
-          }
+        final int discrepancies;
+        if (round.discrepancies().containsKey(AuditSelection.AUDITED_CONTEST)) {
+          discrepancies = round.discrepancies().get(AuditSelection.AUDITED_CONTEST);
+        } else {
+          discrepancies = 0;
         }
         cell.setCellValue(discrepancies);
         accumulator = accumulator + discrepancies;
@@ -454,11 +453,11 @@ public class CountyReport {
         cell = row.createCell(cell_number++);
         cell.setCellStyle(integer_style);
         cell.setCellType(CellType.NUMERIC);
-        int discrepancies = 0;
-        for (final Entry<AuditReason, Integer> entry : round.discrepancies().entrySet()) {
-          if (entry.getKey().isUnaudited() && entry.getValue() != null) {
-            discrepancies = discrepancies + entry.getValue();
-          }
+        final int discrepancies;
+        if (round.discrepancies().containsKey(AuditSelection.UNAUDITED_CONTEST)) {
+          discrepancies = round.discrepancies().get(AuditSelection.UNAUDITED_CONTEST);
+        } else {
+          discrepancies = 0;
         }
         cell.setCellValue(discrepancies);
         accumulator = accumulator + discrepancies;
@@ -479,14 +478,14 @@ public class CountyReport {
         cell = row.createCell(cell_number++);
         cell.setCellStyle(integer_style);
         cell.setCellType(CellType.NUMERIC);
-        int disagreements = 0;
-        for (final Entry<AuditReason, Integer> entry : round.disagreements().entrySet()) {
-          if (entry.getKey().isAudited() && entry.getValue() != null) {
-            disagreements = disagreements + entry.getValue();
-          }
+        final int disagreements;
+        if (round.disagreements().containsKey(AuditSelection.AUDITED_CONTEST)) {
+          disagreements = round.discrepancies().get(AuditSelection.AUDITED_CONTEST);
+        } else {
+          disagreements = 0;
         }
-        accumulator = accumulator + disagreements;
         cell.setCellValue(disagreements);
+        accumulator = accumulator + disagreements;
       }
       cell = row.createCell(cell_number++);
       cell.setCellStyle(integer_style);
@@ -504,14 +503,14 @@ public class CountyReport {
         cell = row.createCell(cell_number++);
         cell.setCellStyle(integer_style);
         cell.setCellType(CellType.NUMERIC);
-        int disagreements = 0;
-        for (final Entry<AuditReason, Integer> entry : round.disagreements().entrySet()) {
-          if (entry.getKey().isUnaudited() && entry.getValue() != null) {
-            disagreements = disagreements + entry.getValue();
-          }
+        final int disagreements;
+        if (round.disagreements().containsKey(AuditSelection.UNAUDITED_CONTEST)) {
+          disagreements = round.discrepancies().get(AuditSelection.UNAUDITED_CONTEST);
+        } else {
+          disagreements = 0;
         }
-        accumulator = accumulator + disagreements;
         cell.setCellValue(disagreements);
+        accumulator = accumulator + disagreements;
       }
       cell = row.createCell(cell_number++);
       cell.setCellStyle(integer_style);
@@ -639,25 +638,23 @@ public class CountyReport {
       
       row = round_sheet.createRow(row_number++);
       cell_number = 1; // these are headers for audit reasons
-      final List<AuditReason> listed_reasons = new ArrayList<>();
-      final Map<AuditReason, Integer> discrepancies = round.discrepancies();
-      final Map<AuditReason, Integer> disagreements = round.disagreements();
+      final List<AuditSelection> listed_selections = new ArrayList<>();
+      final Map<AuditSelection, Integer> discrepancies = round.discrepancies();
+      final Map<AuditSelection, Integer> disagreements = round.disagreements();
       
-      for (final AuditReason r : AuditReason.values()) {
-        if (discrepancies.containsKey(r) && discrepancies.get(r) >= 0 || 
-            disagreements.containsKey(r) && disagreements.get(r) >= 0) {
-          listed_reasons.add(r);
+      for (final AuditSelection s : AuditSelection.values()) {
+        if (discrepancies.containsKey(s) && discrepancies.get(s) >= 0 || 
+            disagreements.containsKey(s) && disagreements.get(s) >= 0) {
+          listed_selections.add(s);
         }
       }
-      for (final AuditReason r : listed_reasons) {
+      
+      Collections.sort(listed_selections);
+      
+      for (final AuditSelection s : listed_selections) {
         cell = row.createCell(cell_number++);
         cell.setCellStyle(bold_right_style);
-        if (r == AuditReason.OPPORTUNISTIC_BENEFITS) {
-          // Colorado has an aversion to the phrase "opportunistic benefits"
-          cell.setCellValue("Unaudited Contest");
-        } else {
-          cell.setCellValue(r.prettyString());
-        }
+        cell.setCellValue(s.prettyString());
       }
       
       row = round_sheet.createRow(row_number++);
@@ -669,14 +666,14 @@ public class CountyReport {
       if (discrepancies.isEmpty()) {
         cell.setCellValue("No Discrepancies Recorded");
       } else {
-        cell.setCellValue("Discrepancies Recorded by Audit Reason");
-        for (final AuditReason r : listed_reasons) {
+        cell.setCellValue("Discrepancies Recorded");
+        for (final AuditSelection s : listed_selections) {
           cell = row.createCell(cell_number++);
           cell.setCellType(CellType.NUMERIC);
           cell.setCellStyle(integer_style);
           final int cell_value;
-          if (discrepancies.containsKey(r)) {
-            cell_value = discrepancies.get(r);
+          if (discrepancies.containsKey(s)) {
+            cell_value = discrepancies.get(s);
           } else {
             cell_value = 0;
           }
@@ -693,14 +690,14 @@ public class CountyReport {
       if (disagreements.isEmpty()) {
         cell.setCellValue("No Disagreements Recorded");
       } else {
-        cell.setCellValue("Disagreements Recorded by Audit Reason");
-        for (final AuditReason r : listed_reasons) {
+        cell.setCellValue("Disagreements Recorded");
+        for (final AuditSelection s : listed_selections) {
           cell = row.createCell(cell_number++);
           cell.setCellType(CellType.NUMERIC);
           cell.setCellStyle(integer_style);
           final int cell_value;
-          if (disagreements.containsKey(r)) {
-            cell_value = disagreements.get(r);
+          if (disagreements.containsKey(s)) {
+            cell_value = disagreements.get(s);
           } else {
             cell_value = 0;
           }


### PR DESCRIPTION
This changes the discrepancy and disagreement counters stored in rounds and the county dashboard (and thus displayed on the county and state dashboard UIs) to count ballot cards at most one time each.