### PR TITLE
Dispatch network fail actions for more failed fetches.

### DIFF
--- a/client/src/action/county/uploadBallotManifest.ts
+++ b/client/src/action/county/uploadBallotManifest.ts
@@ -38,11 +38,7 @@ async function importBallotManifest(body: any) {
 
         action('IMPORT_BALLOT_MANIFEST_OK', data);
     } catch (e) {
-        if (e.message === 'Failed to fetch') {
-            action('IMPORT_BALLOT_MANIFEST_NETWORK_FAIL');
-        }
-
-        action('INTERNAL_ERROR');
+        action('IMPORT_BALLOT_MANIFEST_NETWORK_FAIL');
 
         throw e;
     }
@@ -75,11 +71,7 @@ async function uploadBallotManifest(countyId: number, file: Blob, hash: string) 
 
         importBallotManifest(received);
     } catch (e) {
-        if (e.message === 'Failed to fetch') {
-            action('UPLOAD_BALLOT_MANIFEST_NETWORK_FAIL');
-        }
-
-        action('INTERNAL_ERROR');
+        action('UPLOAD_BALLOT_MANIFEST_NETWORK_FAIL');
 
         throw e;
     }

--- a/client/src/action/county/uploadCvrExport.ts
+++ b/client/src/action/county/uploadCvrExport.ts
@@ -38,11 +38,7 @@ async function importCvrExport(body: any) {
 
         action('IMPORT_CVR_EXPORT_OK', data);
     } catch (e) {
-        if (e.message === 'Failed to fetch') {
-            action('IMPORT_CVR_EXPORT_NETWORK_FAIL');
-        }
-
-        action('INTERNAL_ERROR');
+        action('IMPORT_CVR_EXPORT_NETWORK_FAIL');
 
         throw e;
     }
@@ -75,11 +71,7 @@ async function uploadCvrExport(countyId: number, file: Blob, hash: string) {
 
         importCvrExport(received);
     } catch (e) {
-        if (e.message === 'Failed to fetch') {
-            action('UPLOAD_CVR_EXPORT_NETWORK_FAIL');
-        }
-
-        action('INTERNAL_ERROR');
+        action('UPLOAD_CVR_EXPORT_NETWORK_FAIL');
 
         throw e;
     }

--- a/client/src/action/createFetchAction.ts
+++ b/client/src/action/createFetchAction.ts
@@ -42,11 +42,7 @@ function createFetchAction(config: CreateFetchConfig) {
 
             action(okType, data);
         } catch (e) {
-            if (e.message === 'Failed to fetch') {
-                action(networkFailType);
-            }
-
-            action('INTERNAL_ERROR');
+            action(networkFailType);
 
             throw e;
         }

--- a/client/src/action/createSubmitAction.ts
+++ b/client/src/action/createSubmitAction.ts
@@ -55,11 +55,7 @@ function createSubmitAction(config: CreateSubmitConfig) {
 
             action(okType, data);
         } catch (e) {
-            if (e.message === 'Failed to fetch') {
-                action(networkFailType);
-            }
-
-            action('INTERNAL_ERROR');
+            action(networkFailType);
 
             throw e;
         }


### PR DESCRIPTION
Closes #775.

Until now, we only dispatched `..._NETWORK_FAIL` actions when a `fetch`
failed and the browser deemed it a network error _of a certain kind_,
per the `message` property of the thrown error. However, we shouldn't
assume that all browsers will set the error's `message` property in
the same way, and we should recover robustly when we are unable to
parse JSON from the response body (e.g. due to an error at the level
of a reverse proxy server).

By being too picky about what the thrown error looked like, we were
failing to clean up after certain kinds of non-HTTP/network error,
which was usually asymptomatic, but in the case of ballot manifest and
CVR export uploads, could lead to a "stuck" spinner state. These
changes fix that.