### PR TITLE
Update to 1.0.3, change C3P0 settings to not cull idle threads.

### DIFF
--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>us.freeandfair.production</groupId>
 	<artifactId>colorado_rla</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<name>ColoradoRLA</name>
 	<description>A risk-limiting audit system for the State of Colorado</description>
 	<properties>

--- a/server/eclipse-project/src/main/resources/us/freeandfair/corla/default.properties
+++ b/server/eclipse-project/src/main/resources/us/freeandfair/corla/default.properties
@@ -24,4 +24,4 @@ hibernate.c3p0.min_size = 5
 hibernate.c3p0.max_size = 20
 hibernate.c3p0.timeout = 300
 hibernate.c3p0.max_statements = 0
-hibernate.c3p0.idle_test_period = 3000
+hibernate.c3p0.idle_test_period = 0


### PR DESCRIPTION
We're eliminating the class loading problem by removing C3P0's motivation to load the class, for the moment; the default configuration now does not time out idle DB connection threads.