### PR TITLE
Update to fix a constraint error when cleaning up old records.

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -249,6 +249,9 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
         Persistence.beginTransaction();
         final DoSDashboard dosdb = Persistence.getByID(DoSDashboard.ID, DoSDashboard.class);
         dosdb.removeContestsToAuditForCounty(the_county);
+        // prevent Hibernate from reordering the ContestsToAudit deletion after the
+        // Contest and CountyContestResult deletion in the following queries
+        Persistence.flush(); 
         result = 
             CastVoteRecordQueries.deleteMatching(the_county.id(), RecordType.UPLOADED);
         CountyContestResultQueries.deleteForCounty(the_county.id());


### PR DESCRIPTION
Hibernate sometimes reorders things. This code change forces it to flush some changes so they can't be reordered after other changes that would cause a foreign key constraint to fail.