### PR TITLE
Server Fixes based on CDOS and Other Reports

### DIFF
--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -203,5 +203,10 @@
 			<artifactId>maven-model</artifactId>
 			<version>3.5.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.6</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>us.freeandfair.production</groupId>
 	<artifactId>colorado_rla</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.4-dev</version>
 	<name>ColoradoRLA</name>
 	<description>A risk-limiting audit system for the State of Colorado</description>
 	<properties>

--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>us.freeandfair.production</groupId>
 	<artifactId>colorado_rla</artifactId>
-	<version>1.0.3</version>
+	<version>1.0.4</version>
 	<name>ColoradoRLA</name>
 	<description>A risk-limiting audit system for the State of Colorado</description>
 	<properties>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -171,7 +171,7 @@ public final class Main {
       final Model model = reader.read(isr);
       version = model.getVersion();
     } catch (final IOException | XmlPullParserException e) {
-      // version is already set to "UNKNOWN"
+      LOGGER.info("could not obtain version number: " + e);
     }
     VERSION = version;
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -15,6 +15,7 @@ import static spark.Spark.*;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -164,14 +165,30 @@ public final class Main {
   // Version Initializer
   
   static {
+    final String pom_location =
+        "/META-INF/maven/us.freeandfair.production/colorado_rla/pom.xml";
+    final File pom = new File("pom.xml");
     String version = "UNKNOWN";
-    try (InputStreamReader isr = 
-         new InputStreamReader(new FileInputStream("pom.xml"), "UTF-8")) {
-      final MavenXpp3Reader reader = new MavenXpp3Reader();
-      final Model model = reader.read(isr);
-      version = model.getVersion();
-    } catch (final IOException | XmlPullParserException e) {
-      LOGGER.info("could not obtain version number: " + e);
+    InputStream pom_stream = null;
+    
+    if (pom.exists()) {
+      try {
+        pom_stream = new FileInputStream(pom);
+      } catch (final FileNotFoundException e) {
+        // this can't happen because we tested that the file existed
+      }
+    } else {
+      pom_stream = Main.class.getResourceAsStream(pom_location);
+    }
+    
+    if (pom_stream != null) {
+      try (InputStreamReader isr = new InputStreamReader(pom_stream, "UTF-8")) {
+        final MavenXpp3Reader reader = new MavenXpp3Reader();
+        final Model model = reader.read(isr);
+        version = model.getVersion();
+      } catch (final IOException | XmlPullParserException e) {
+        LOGGER.info("could not obtain version number: " + e);
+      }
     }
     VERSION = version;
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownload.java
@@ -70,7 +70,7 @@ public class ACVRDownload extends AbstractEndpoint {
   @Override
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
          BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
          JsonWriter jw = new JsonWriter(bw)) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRDownloadByCounty.java
@@ -72,7 +72,7 @@ public class ACVRDownloadByCounty extends AbstractEndpoint {
   @Override
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     final Set<Long> county_set = new HashSet<Long>();
     for (final String s : the_request.queryParams()) {
       county_set.add(Long.valueOf(s));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
@@ -81,7 +81,7 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final SubmittedAuditCVR submission =
           Main.GSON.fromJson(the_request.body(), SubmittedAuditCVR.class);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AbstractEndpoint.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import javax.persistence.PersistenceException;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.log4j.Level;
 import org.eclipse.jetty.http.HttpStatus;
 
@@ -37,6 +38,7 @@ import us.freeandfair.corla.model.LogEntry;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.LogEntryQueries;
 import us.freeandfair.corla.util.SuppressFBWarnings;
+
 /**
  * Basic behaviors that span all endpoints. In particular, standard exceptional
  * behavior with regards to cross-cutting concerns like authentication or
@@ -430,6 +432,45 @@ public abstract class AbstractEndpoint implements Endpoint {
     // Load and check the ASM
     loadAndCheckASM(the_request, the_response);
   } 
+  
+  /**
+   * The main body of the endpoint. This method wraps an execution of the
+   * endpointBody() method of a child class in a way such that unexpected
+   * exceptions will be properly logged rather than causing thread deaths.
+   * 
+   * @param the_request The request.
+   * @param the_response The response.
+   * @return the result of the endpoint execution.
+   */
+  // catching generic exception is necessary because that's how we can keep the
+  // server running as best it can, and log the unhandled exception, without killing
+  // a Spark thread and hanging a database transaction
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  public final String endpoint(final Request the_request, final Response the_response) {
+    String result = null;
+    
+    try {
+      result = endpointBody(the_request, the_response);
+    } catch (final Exception e) {
+      // some exception occurred that was not handled within the endpoint, so
+      // handle it as a generic server error and log the stack trace
+      Main.LOGGER.error("uncaught exception in endpoint " + endpointName() + ":\n" + 
+                        ExceptionUtils.getStackTrace(e));
+      serverError(the_response, e.toString());
+      // the server error halts processing
+    }
+    
+    return result;
+  }
+  
+  /**
+   * The main body of the endpoint to be executed in child classes.
+   * 
+   * @param the_request The request
+   * @param the_response The response.
+   * @return the result of the endpoint execution.
+   */
+  protected abstract String endpointBody(Request the_request, Response the_response);
   
   /**
    * The after filter for this endpoint. Currently, the implementation is empty.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardDashboardASMState.java
@@ -55,7 +55,7 @@ public class AuditBoardDashboardASMState extends AbstractAuditBoardDashboardEndp
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // there's really nothing to do here other than get the ASM state, which we
     // conveniently have locally already
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignIn.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignIn.java
@@ -78,7 +78,7 @@ public class AuditBoardSignIn extends AbstractAuditBoardDashboardEndpoint {
   @Override
   // false positive about inner class declaration
   @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     try {
       final Type list_type = new TypeToken<List<Elector>>() { }.getType();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignOut.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignOut.java
@@ -71,7 +71,7 @@ public class AuditBoardSignOut extends AbstractAuditBoardDashboardEndpoint {
   @Override
   // false positive about inner class declaration
   @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     try {
       final County county = Main.authentication().authenticatedCounty(the_request); 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditInvestigationReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditInvestigationReport.java
@@ -71,7 +71,7 @@ public class AuditInvestigationReport extends AbstractAuditBoardDashboardEndpoin
    * Submit an audit investigation report.
    */
   @Override
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     try {
       final AuditInvestigationReportInfo report =

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateAdministrator.java
@@ -90,7 +90,7 @@ public class AuthenticateAdministrator extends AbstractEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     final SubmittedCredentials credentials =
         Main.authentication().authenticationCredentials(the_request);
     if (Main.authentication().secondFactorAuthenticated(the_request) &&

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateCountyAdministrator.java
@@ -55,7 +55,7 @@ public class AuthenticateCountyAdministrator extends AbstractEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     final SubmittedCredentials credentials =
         Main.authentication().authenticationCredentials(the_request);
     if (Main.authentication().

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuthenticateStateAdministrator.java
@@ -58,7 +58,7 @@ public class AuthenticateStateAdministrator extends AbstractEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     final SubmittedCredentials credentials =
         Main.authentication().authenticationCredentials(the_request);
     if (Main.authentication().

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownload.java
@@ -56,7 +56,7 @@ public class BallotManifestDownload extends AbstractCountyDashboardEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
          BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
          JsonWriter jw = new JsonWriter(bw)) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestDownloadByCounty.java
@@ -57,7 +57,7 @@ public class BallotManifestDownloadByCounty extends AbstractCountyDashboardEndpo
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     if (validateParameters(the_request)) {
       final Set<Integer> county_set = new HashSet<Integer>();
       for (final String s : the_request.queryParams()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestImport.java
@@ -153,7 +153,7 @@ public class BallotManifestImport extends AbstractCountyDashboardEndpoint {
    */
   @Override
   @SuppressWarnings({"PMD.ConfusingTernary"})
-  public String endpoint(final Request the_request, final Response the_response) {    
+  public String endpointBody(final Request the_request, final Response the_response) {    
     // we know we have county authorization, so let's find out which county
     final County county = Main.authentication().authenticatedCounty(the_request);
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotNotFound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotNotFound.java
@@ -99,7 +99,7 @@ public class BallotNotFound extends AbstractAuditBoardDashboardEndpoint {
   // badDataContents() (which ends the method's execution) would get called first
   @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
   @SuppressWarnings("PMD.NPathComplexity")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // we must be authenticated as a county
     final County county = Main.authentication().authenticatedCounty(the_request);
     if (county == null) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownload.java
@@ -70,7 +70,7 @@ public class CVRDownload extends AbstractEndpoint {
   @Override
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
          BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
          JsonWriter jw = new JsonWriter(bw)) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByCounty.java
@@ -72,7 +72,7 @@ public class CVRDownloadByCounty extends AbstractEndpoint {
   @Override
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     final Set<Long> county_set = new HashSet<Long>();
     for (final String s : the_request.queryParams()) {
       county_set.add(Long.valueOf(s));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRDownloadByID.java
@@ -64,7 +64,7 @@ public class CVRDownloadByID extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final CastVoteRecord c = 
           Persistence.getByID(Long.parseLong(the_request.params(":id")),

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -384,7 +384,7 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
    */
   @Override
   @SuppressWarnings({"PMD.ConfusingTernary"})
-  public String endpoint(final Request the_request, final Response the_response) {    
+  public String endpointBody(final Request the_request, final Response the_response) {    
     // we know we have county authorization, so let's find out which county
     final County county = Main.authentication().authenticatedCounty(the_request);
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -171,14 +171,14 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
         Main.LOGGER.info(imported + " CVRs parsed from file " + the_file.id() + 
                          " for county " + the_file.county().id());
         updateCountyDashboard(the_response, the_file, ImportStatus.SUCCESSFUL, imported);
-        the_file.setStatus(FileStatus.IMPORTED_AS_CVR_EXPORT);
-        Persistence.saveOrUpdate(the_file);
         handleTies(the_response, the_file.county());
         final Map<String, Integer> response = new HashMap<String, Integer>();
         response.put("records_imported", imported);
         if (deleted > 0) {
           response.put("records_deleted", deleted);
         }
+        the_file.setStatus(FileStatus.IMPORTED_AS_CVR_EXPORT);
+        Persistence.saveOrUpdate(the_file);
         okJSON(the_response, Main.GSON.toJson(response));
       } else {
         try {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -166,7 +166,7 @@ public class CVRToAuditDownload extends AbstractEndpoint {
   @Override
   @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength", 
                      "checkstyle:methodlength", "checkstyle:executablestatementcount"})
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // we know we have either state or county authentication; this will be null
     // for state authentication
     County county = Main.authentication().authenticatedCounty(the_request);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -142,7 +142,7 @@ public class CVRToAuditList extends AbstractEndpoint {
    */
   @Override
   @SuppressWarnings("PMD.NPathComplexity")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // we know we have either state or county authentication; this will be null
     // for state authentication
     County county = Main.authentication().authenticatedCounty(the_request);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
@@ -68,7 +68,7 @@ public class ContestDownload extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // only return contests for counties that have finished their uploads
     final Set<County> county_set = new HashSet<>();
     for (final CountyDashboard cdb : Persistence.getAll(CountyDashboard.class)) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByCounty.java
@@ -68,7 +68,7 @@ public class ContestDownloadByCounty extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     if (validateParameters(the_request)) {
       final Set<County> county_set = new HashSet<County>();
       for (final String s : the_request.queryParams()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownloadByID.java
@@ -64,7 +64,7 @@ public class ContestDownloadByID extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final Contest c = 
           Persistence.getByID(Long.parseLong(the_request.params(":id")),

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardASMState.java
@@ -55,7 +55,7 @@ public class CountyDashboardASMState extends AbstractCountyDashboardEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // there's really nothing to do here other than get the ASM state, which we
     // conveniently have locally already
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
@@ -64,7 +64,7 @@ public class CountyDashboardRefresh extends AbstractCountyDashboardEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final County county = Main.authentication().authenticatedCounty(the_request);
           

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyReportDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyReportDownload.java
@@ -15,6 +15,8 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.persistence.PersistenceException;
 
@@ -24,6 +26,10 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMState;
+import us.freeandfair.corla.asm.ASMState.DoSDashboardState;
+import us.freeandfair.corla.asm.ASMUtilities;
+import us.freeandfair.corla.asm.DoSDashboardASM;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.report.CountyReport;
@@ -41,6 +47,16 @@ public class CountyReportDownload extends AbstractEndpoint {
    * The "county" parameter.
    */
   public static final String COUNTY = "county";
+  
+  /**
+   * The states in which this endpoint can provide a result.
+   */
+  private static final List<ASMState> LEGAL_STATES = 
+      Arrays.asList(DoSDashboardState.COMPLETE_AUDIT_INFO_SET,
+                    DoSDashboardState.DOS_AUDIT_ONGOING, 
+                    DoSDashboardState.DOS_ROUND_COMPLETE,
+                    DoSDashboardState.DOS_AUDIT_COMPLETE,
+                    DoSDashboardState.AUDIT_RESULTS_PUBLISHED);
   
   /**
    * {@inheritDoc}
@@ -98,6 +114,13 @@ public class CountyReportDownload extends AbstractEndpoint {
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
   public String endpoint(final Request the_request, final Response the_response) {
+    // if we haven't defined the election, this is "data not found"
+    final DoSDashboardASM dos_asm = ASMUtilities.asmFor(DoSDashboardASM.class, 
+                                                        DoSDashboardASM.IDENTITY);
+    if (!LEGAL_STATES.contains(dos_asm.currentState())) {
+      dataNotFound(the_response, "No state report available in this state.");
+    }
+    
     // we know we have either state or county authentication; this will be null
     // for state authentication
     County county = Main.authentication().authenticatedCounty(the_request);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyReportDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyReportDownload.java
@@ -113,7 +113,7 @@ public class CountyReportDownload extends AbstractEndpoint {
   @Override
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // if we haven't defined the election, this is "data not found"
     final DoSDashboardASM dos_asm = ASMUtilities.asmFor(DoSDashboardASM.class, 
                                                         DoSDashboardASM.IDENTITY);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardASMState.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardASMState.java
@@ -55,7 +55,7 @@ public class DoSDashboardASMState extends AbstractDoSDashboardEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // there's really nothing to do here other than get the ASM state, which we
     // conveniently have locally already
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/DoSDashboardRefresh.java
@@ -63,7 +63,7 @@ public class DoSDashboardRefresh extends AbstractDoSDashboardEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       okJSON(the_response, 
              Main.GSON.toJson(DoSDashboardRefreshResponse.createResponse

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Endpoint.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Endpoint.java
@@ -43,7 +43,7 @@ public interface Endpoint {
   String endpointName();
  
   /**
-   * A Spark endpoint.
+   * The main body of the endpoint. 
    *
    * @param the_request The request object.
    * @param the_response The response object.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/FileDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/FileDownload.java
@@ -91,7 +91,7 @@ public class FileDownload extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // we know we have either state or county authentication; this will be null
     // for state authentication
     final County county = Main.authentication().authenticatedCounty(the_request);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/FileUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/FileUpload.java
@@ -220,7 +220,7 @@ public class FileUpload extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     final UploadInformation info = new UploadInformation();
     info.my_timestamp = Instant.now();
     info.my_ok = true;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IndicateHandCount.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IndicateHandCount.java
@@ -102,7 +102,7 @@ public class IndicateHandCount extends AbstractDoSDashboardEndpoint {
    * @param the_response The response.
    */
   @Override
-  public synchronized String endpoint(final Request the_request, 
+  public synchronized String endpointBody(final Request the_request, 
                                       final Response the_response) {
     try {
       final ContestToAudit[] supplied_ctas = 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
@@ -70,7 +70,7 @@ public class IntermediateAuditReport extends AbstractAuditBoardDashboardEndpoint
    * Publish the intermediate audit report by the audit board.
    */
   @Override
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     try {
       final IntermediateAuditReportInfo report =

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishAuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishAuditReport.java
@@ -61,7 +61,7 @@ public class PublishAuditReport extends AbstractDoSDashboardEndpoint {
    * Download all of the data relevant to public auditing of a RLA.
    */
   @Override
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     ok(the_response, "Publish the audit report for the entire state-wide RLA.");
     return my_endpoint_result.get();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishDataToAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/PublishDataToAudit.java
@@ -50,7 +50,7 @@ public class PublishDataToAudit extends AbstractDoSDashboardEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     ok(the_response, "When defined, the full set of data relevant to permitting the" +
                      "public to audit an RLA will be downloaded here.");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ReportBallotsToAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ReportBallotsToAudit.java
@@ -50,7 +50,7 @@ public class ReportBallotsToAudit extends AbstractDoSDashboardEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     ok(the_response, "the report of ballots to audit is not yet implemented, but " + 
                      "the information can be obtained from county dashboard states");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ResetDatabase.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ResetDatabase.java
@@ -83,7 +83,7 @@ public class ResetDatabase extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     // delete everything
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/RiskLimitForComparisonAudits.java
@@ -75,7 +75,7 @@ public class RiskLimitForComparisonAudits extends AbstractDoSDashboardEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final AuditInfo risk_limit = 
           Main.GSON.fromJson(the_request.body(), AuditInfo.class);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Root.java
@@ -44,7 +44,7 @@ public class Root extends AbstractEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     ok(the_response, "ColoradoRLA Server, Version " + Main.VERSION + " - " +
                      "Please Use a Valid Endpoint!");
     return my_endpoint_result.get();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SelectContestsForAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SelectContestsForAudit.java
@@ -79,7 +79,7 @@ public class SelectContestsForAudit extends AbstractDoSDashboardEndpoint {
    * @param the_response The response.
    */
   @Override
-  public synchronized String endpoint(final Request the_request, 
+  public synchronized String endpointBody(final Request the_request, 
                                       final Response the_response) {
     try {
       final ContestToAudit[] contests = 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetRandomSeed.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetRandomSeed.java
@@ -72,7 +72,7 @@ public class SetRandomSeed extends AbstractDoSDashboardEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final AuditInfo submitted = 
           Main.GSON.fromJson(the_request.body(), AuditInfo.class);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
@@ -103,7 +103,7 @@ public class SignOffAuditRound extends AbstractAuditBoardDashboardEndpoint {
   // false positive about inner class declaration
   @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
   @SuppressWarnings("checkstyle:nestedifdepth")
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     try {
       final Type list_type = new TypeToken<List<Elector>>() { }.getType();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
@@ -102,7 +102,7 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
    * {@inheritDoc}
    */
   @Override
-  public String endpoint(final Request the_request,
+  public String endpointBody(final Request the_request,
                          final Response the_response) {
     if (my_asm.get().currentState() == RANDOM_SEED_PUBLISHED) {
       // the audit hasn't started yet, so start round 1 and ignore the parameters

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
@@ -15,6 +15,8 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.persistence.PersistenceException;
 
@@ -23,6 +25,10 @@ import org.apache.cxf.attachment.Rfc5987Util;
 import spark.Request;
 import spark.Response;
 
+import us.freeandfair.corla.asm.ASMState;
+import us.freeandfair.corla.asm.ASMState.DoSDashboardState;
+import us.freeandfair.corla.asm.ASMUtilities;
+import us.freeandfair.corla.asm.DoSDashboardASM;
 import us.freeandfair.corla.report.StateReport;
 import us.freeandfair.corla.util.SparkHelper;
 
@@ -34,6 +40,16 @@ import us.freeandfair.corla.util.SparkHelper;
  */
 @SuppressWarnings("PMD.AtLeastOneConstructor")
 public class StateReportDownload extends AbstractEndpoint {
+  /**
+   * The states in which this endpoint can provide a result.
+   */
+  private static final List<ASMState> LEGAL_STATES = 
+      Arrays.asList(DoSDashboardState.COMPLETE_AUDIT_INFO_SET,
+                    DoSDashboardState.DOS_AUDIT_ONGOING, 
+                    DoSDashboardState.DOS_ROUND_COMPLETE,
+                    DoSDashboardState.DOS_AUDIT_COMPLETE,
+                    DoSDashboardState.AUDIT_RESULTS_PUBLISHED);
+  
   /**
    * {@inheritDoc}
    */
@@ -65,6 +81,13 @@ public class StateReportDownload extends AbstractEndpoint {
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
   public String endpoint(final Request the_request, final Response the_response) {
+    // if we haven't defined the election, this is "data not found"
+    final DoSDashboardASM dos_asm = ASMUtilities.asmFor(DoSDashboardASM.class, 
+                                                        DoSDashboardASM.IDENTITY);
+    if (!LEGAL_STATES.contains(dos_asm.currentState())) {
+      dataNotFound(the_response, "No state report available in this state.");
+    }
+    
     final boolean pdf = "pdf".equalsIgnoreCase(the_request.queryParams("file_type"));
     final StateReport sr = new StateReport();
     byte[] file = new byte[0];

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StateReportDownload.java
@@ -80,7 +80,7 @@ public class StateReportDownload extends AbstractEndpoint {
   @Override
   // necessary to break out of the lambda expression in case of IOException
   @SuppressWarnings("PMD.ExceptionAsFlowControl")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     // if we haven't defined the election, this is "data not found"
     final DoSDashboardASM dos_asm = ASMUtilities.asmFor(DoSDashboardASM.class, 
                                                         DoSDashboardASM.IDENTITY);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Unauthenticate.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/Unauthenticate.java
@@ -84,7 +84,7 @@ public class Unauthenticate extends AbstractEndpoint {
    * @param the_response The response.
    */
   @Override
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     Main.authentication().deauthenticate(the_request);
     ok(the_response, "Unauthenticated");
     return my_endpoint_result.get();

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UpdateAuditInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UpdateAuditInfo.java
@@ -82,7 +82,7 @@ public class UpdateAuditInfo extends AbstractDoSDashboardEndpoint {
    */
   @Override
   @SuppressWarnings("PMD.UselessParentheses")
-  public String endpoint(final Request the_request, final Response the_response) {
+  public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final AuditInfo info = 
           Main.GSON.fromJson(the_request.body(), AuditInfo.class);


### PR DESCRIPTION
Fixes the issue where a 500 error is generated and server hangs when a report is generated at an inappropriate time.

Fixes the issue noted by CDOS where the "uploaded_file" table status does not get updated

Fixes UNKNOWN version numbers.

Attempts to ensure that database transactions are not left hanging, by keeping Spark threads from dying unexpectedly in unanticipated, but not server life threatening, situations.

Closes #836 
Closes #838
Closes #840 
Closes #841 