### PR TITLE
Property Parsing and Utilization Fix

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 import java.util.Scanner;
@@ -485,12 +486,41 @@ public final class Main {
   }
   
   /**
+   * Generates a string representation of a Properties object, including all
+   * properties (even default ones).
+   * 
+   * @param the_properties The Properties object.
+   * @return the string representation.
+   */
+  private static String propertiesString(final Properties the_properties) {
+    final StringBuilder sb = new StringBuilder();
+    
+    sb.append('{');
+    final Enumeration<?> property_names = the_properties.propertyNames();
+    boolean not_first = false;
+    while (property_names.hasMoreElements()) {
+      final Object prop = property_names.nextElement();
+      if (not_first) {
+        sb.append(", ");
+      } else {
+        not_first = true;
+      }
+      sb.append(prop.toString());
+      sb.append('=');
+      sb.append(the_properties.getProperty(prop.toString()));
+    }
+    sb.append('}');  
+    
+    return sb.toString();
+  }
+  
+  /**
    * Starts a ColoradoRLA server.
    */
   public void start() {
     LOGGER.info("starting server version " + VERSION + " with properties: " + 
-                static_properties);
-
+                propertiesString(static_properties));
+    
     // provide properties to the persistence engine
     Persistence.setProperties(static_properties);
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
@@ -272,7 +272,7 @@ public class DominionCVRExportParser implements CVRExportParser {
   private int parseProperty(final Properties the_properties, 
                             final String the_property_name, 
                             final int the_default_value) {
-    int result = the_default_value;
+    int result;
     
     try {
       result = Integer.parseInt(the_properties.getProperty(the_property_name, 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
@@ -274,12 +274,11 @@ public class DominionCVRExportParser implements CVRExportParser {
                             final int the_default_value) {
     int result = the_default_value;
     
-    if (the_properties.containsKey(the_property_name)) {
-      try {
-        result = Integer.parseInt(the_properties.getProperty(the_property_name));
-      } catch (final NumberFormatException e) {
-        result = the_default_value;
-      }
+    try {
+      result = Integer.parseInt(the_properties.getProperty(the_property_name, 
+                                                           String.valueOf(the_default_value)));
+    } catch (final NumberFormatException e) {
+      result = the_default_value;
     }
     
     return result;


### PR DESCRIPTION
This PR works around two truly absurd aspect of the Java Properties API:

- a `Properties` object will return `false` when asked if it has a property with a specific key, even if it has a default value for a property with that key. 
- `toString()` on a `Properties` object prints only the _explicit_ properties, and not the ones that only exist as defaults.
