### PR TITLE
File upload polling

### DIFF
--- a/client/src/component/County/Dashboard/CVRExport/Uploading.tsx
+++ b/client/src/component/County/Dashboard/CVRExport/Uploading.tsx
@@ -25,7 +25,7 @@ const Progress = (props: ProgressProps) => {
     return (
         <div className='rla-file-upload-progress'>
             <div>
-                <strong>Progress:</strong> { progressPercent }%
+                <strong>Import progress:</strong> { progressPercent }%
             </div>
             <ProgressBar className='pt-intent-primary' value={ progressRatio } />
         </div>
@@ -44,16 +44,20 @@ const Uploading = (props: UploadingProps) => {
     if (!cvrExport) { return null; }
     if (!cvrImportStatus) { return null; }
 
-    const progress = cvrImportStatus === 'IN_PROGRESS'
-                   ? <Progress file={ cvrExport } count={ cvrExportCount } />
-                   : null;
-
-    return (
-        <div className='pt-card'>
-            <Spinner className='pt-large' intent={ Intent.PRIMARY } />
-            { progress }
-        </div>
-    );
+    if (cvrImportStatus === 'IN_PROGRESS') {
+        return (
+            <div className='pt-card'>
+                <Progress file={ cvrExport } count={ cvrExportCount } />
+            </div>
+        );
+    } else {
+        return (
+            <div className='pt-card'>
+                <Spinner className='pt-large' intent={ Intent.PRIMARY } />
+                <div>Uploading file...</div>
+            </div>
+        );
+    }
 };
 
 

--- a/client/src/saga/county/sync.ts
+++ b/client/src/saga/county/sync.ts
@@ -30,9 +30,9 @@ function* auditPoll() {
 
 const auditPollSaga = createPollSaga(
     [auditPoll],
-    COUNTY_POLL_DELAY,
     'COUNTY_AUDIT_POLL_START',
     'COUNTY_AUDIT_POLL_STOP',
+    () => COUNTY_POLL_DELAY,
 );
 
 function* boardSignInSaga() {
@@ -57,9 +57,9 @@ function* dashboardPoll() {
 
 const dashboardPollSaga = createPollSaga(
     [dashboardPoll],
-    COUNTY_POLL_DELAY,
     'COUNTY_DASHBOARD_POLL_START',
     'COUNTY_DASHBOARD_POLL_STOP',
+    () => COUNTY_POLL_DELAY,
 );
 
 

--- a/client/src/saga/county/sync.ts
+++ b/client/src/saga/county/sync.ts
@@ -11,6 +11,8 @@ import fetchAuditBoardASMState from 'corla/action/county/fetchAuditBoardASMState
 import fetchContests from 'corla/action/county/fetchContests';
 import fetchCountyASMState from 'corla/action/county/fetchCountyASMState';
 
+import cvrExportUploadingSelector from 'corla/selector/county/cvrExportUploading';
+
 
 const COUNTY_POLL_DELAY = config.pollDelay;
 
@@ -55,11 +57,21 @@ function* dashboardPoll() {
     }
 }
 
+function* selectPollDelay() {
+    const countyState = yield select();
+
+    const isUploading = cvrExportUploadingSelector(countyState);
+
+    const delay = isUploading ? 5000 : COUNTY_POLL_DELAY;
+
+    return delay;
+}
+
 const dashboardPollSaga = createPollSaga(
     [dashboardPoll],
     'COUNTY_DASHBOARD_POLL_START',
     'COUNTY_DASHBOARD_POLL_STOP',
-    () => COUNTY_POLL_DELAY,
+    selectPollDelay,
 );
 
 

--- a/client/src/saga/createPollSaga.ts
+++ b/client/src/saga/createPollSaga.ts
@@ -1,18 +1,23 @@
 import { delay } from 'redux-saga';
+import { SelectEffect } from 'redux-saga/effects';
 import { cancel, fork, take } from 'redux-saga/effects';
 
 
+type SelectPollDelay = () => number | IterableIterator<number | SelectEffect>;
+
 function createPollSaga(
     pollActions: any[],
-    pollDelay: number,
     pollStart: string,
     pollStop: string,
+    selectPollDelay: SelectPollDelay,
 ) {
     function* pollTask() {
         while (true) {
             for (const a of pollActions) {
                 yield a();
             }
+
+            const pollDelay = yield selectPollDelay();
 
             yield delay(pollDelay);
         }

--- a/client/src/saga/dos/sync.ts
+++ b/client/src/saga/dos/sync.ts
@@ -34,9 +34,9 @@ const DOS_POLL_DELAY = config.pollDelay;
 
 const dashboardPollSaga = createPollSaga(
     [dashboardRefresh, fetchContests],
-    DOS_POLL_DELAY,
     'DOS_DASHBOARD_POLL_START',
     'DOS_DASHBOARD_POLL_STOP',
+    () => DOS_POLL_DELAY,
 );
 
 function* defineAuditSaga() {
@@ -45,9 +45,9 @@ function* defineAuditSaga() {
 
 const selectContestsPollSaga = createPollSaga(
     [dashboardRefresh, fetchContests],
-    DOS_POLL_DELAY,
     'DOS_SELECT_CONTESTS_POLL_START',
     'DOS_SELECT_CONTESTS_POLL_STOP',
+    () => DOS_POLL_DELAY,
 );
 
 function* randomSeedSaga() {


### PR DESCRIPTION
- Dynamically compute the county polling frequency, dependent on CVR import status.
- Improve spinner display logic, so we show a spinner with "Uploading file" text when doing the (blocking) upload, and a progress bar (no spinner) with "Import progress" when asynchronously processing the uploaded file.