### PR TITLE
Improved Async CVR Import Status

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -47,6 +47,7 @@ import us.freeandfair.corla.model.CountyContestResult;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.model.DoSDashboard;
 import us.freeandfair.corla.model.ImportStatus;
+import us.freeandfair.corla.model.ImportStatus.ImportState;
 import us.freeandfair.corla.model.UploadedFile;
 import us.freeandfair.corla.model.UploadedFile.FileStatus;
 import us.freeandfair.corla.model.UploadedFile.HashStatus;
@@ -131,13 +132,21 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
                                    "file " + file.filename() + "uploaded by county " + 
                                    file.county().id());
       } else if (file.hashStatus() == HashStatus.VERIFIED) {
-        // we spawn a thread to do the import, and this endpoint always immediately 
+        // make sure the old CVR file is now marked as "not imported", since the CVRs
+        // will be wiped
+        final CountyDashboard cdb = Persistence.getByID(county.id(), CountyDashboard.class);
+        if (cdb.cvrFile() != null) {
+          cdb.cvrFile().setStatus(FileStatus.NOT_IMPORTED);
+          Persistence.saveOrUpdate(cdb.cvrFile());
+        }
+        // spawn a thread to do the import; this endpoint always immediately 
         // returns a successful result if we get to this point
         synchronized (COUNTIES_RUNNING) {
           // signal that we're starting the import
           COUNTIES_RUNNING.add(county.id());
         }
         (new Thread(new CVRImporter(file))).start();
+        
         okJSON(the_response, Main.GSON.toJson(file));
       } else {
         badDataContents(the_response, "attempt to import a file without a verified hash");
@@ -239,11 +248,18 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
           updateStateMachine(true);
           Persistence.commitTransaction();
           Main.LOGGER.info("CVR import complete for county " + my_file.county().id());
-        } catch (final PersistenceException | CVRImportException e) {
-          // the import failed, so clean up
+        } catch (final PersistenceException e) {
+          // the import failed for DB reasons, so clean up
           Main.LOGGER.error("CVR import failed for county " + my_file.county().id() + ": " + 
               ExceptionUtils.getStackTrace(e));
-          cleanup(my_file.county(), true);
+          cleanup(my_file.county(), true, "import failed because of database problem");
+          updateStateMachine(false);
+          Persistence.commitTransaction();
+        } catch (final CVRImportException e) {
+          // we intentionally failed the import, so clean up
+          Main.LOGGER.error("CVR import failed for county " + my_file.county().id() + ": " + 
+              ExceptionUtils.getStackTrace(e));
+          cleanup(my_file.county(), true, e.getMessage());
           updateStateMachine(false);
           Persistence.commitTransaction();
         } 
@@ -396,7 +412,7 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
             Persistence.saveOrUpdate(cdb);
           } 
           Persistence.commitTransaction();
-          success = true;
+         success = true;
         } catch (final PersistenceException e) {
           // something went wrong, let's try again
           if (Persistence.canTransactionRollback()) {
@@ -448,7 +464,7 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
                                         Main.properties(),
                                         true);
         try {
-          final int deleted = cleanup(the_file.county(), false);
+          final int deleted = cleanup(the_file.county());
           if (deleted > 0) {
             Main.LOGGER.info("deleted " + deleted + " previously-uploaded CVRs");
           }
@@ -456,20 +472,19 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
           error("unable to delete previously uploaded CVRs");
         }
         
-        updateCountyDashboard(the_file, ImportStatus.IN_PROGRESS, 0);
-
-        Persistence.beginTransaction();
+        updateCountyDashboard(the_file, new ImportStatus(ImportState.IN_PROGRESS), 0);
+                
         if (parser.parse()) {
           final int imported = parser.recordCount().getAsInt();
           Main.LOGGER.info(imported + " CVRs parsed from file " + the_file.id() + 
                            " for county " + the_file.county().id());
-          updateCountyDashboard(the_file, ImportStatus.SUCCESSFUL, imported);
+          updateCountyDashboard(the_file, new ImportStatus(ImportState.SUCCESSFUL), imported);
           handleTies(the_file.county());
           the_file.setStatus(FileStatus.IMPORTED_AS_CVR_EXPORT);
           Persistence.saveOrUpdate(the_file);
         } else {
           try {
-            cleanup(the_file.county(), true);
+            cleanup(the_file.county(), true, parser.errorMessage());
           } catch (final PersistenceException e) {
             error("couldn't clean up after " + parser.errorMessage() + " [file " + 
                 the_file.filename() + PAREN_ID + the_file.id() + ")]");
@@ -481,7 +496,7 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
         Main.LOGGER.info("parse transactions did not complete successfully, " + 
                          "attempting cleanup");
         try {
-          cleanup(the_file.county(), true);
+          cleanup(the_file.county(), true, "could not clean up");
         } catch (final PersistenceException ex) {
           // if we couldn't clean up, there's not much we can do about it
         }
@@ -494,7 +509,7 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
                          the_file.filename() + PAREN_ID + the_file.id() +
                          "): " + ExceptionUtils.getStackTrace(e));
         try {
-          cleanup(the_file.county(), true);
+          cleanup(the_file.county(), true, "malformed CVR export file");
         } catch (final PersistenceException ex) {
           // if we couldn't clean up, there's not much we can do about it
         }
@@ -511,12 +526,28 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
      * transaction so that one is open at all times during endpoint execution.
      * 
      * @param the_county The county to wipe.
-     * @param the_failure_flag true to set the CVR import status on the county
-     * dashboard to FAILED, false otherwise.
      * @return the number of deleted CVR records, if any were deleted.
      * @exception PersistenceException if the wipe was unsuccessful.
      */
-    private int cleanup(final County the_county, final boolean the_failure_flag) {
+    private int cleanup(final County the_county) {
+      return cleanup(the_county, false, null);
+    }
+    
+    /**
+     * Attempts to wipe all CVR records for a specific county. This ends any current
+     * transaction, does the delete in its own transaction, and starts a new 
+     * transaction so that one is open at all times during endpoint execution.
+     * 
+     * @param the_county The county to wipe.
+     * @param the_failure_flag true to set the CVR import status on the county
+     * dashboard to FAILED, false otherwise.
+     * @param the_failure_message The failure message to report, if the_failure_flag
+     * is true.
+     * @return the number of deleted CVR records, if any were deleted.
+     * @exception PersistenceException if the wipe was unsuccessful.
+     */
+    private int cleanup(final County the_county, final boolean the_failure_flag, 
+                        final String the_failure_message) {
       if (Persistence.isTransactionActive()) {
         Persistence.commitTransaction();
       }
@@ -542,7 +573,7 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
           cdb.setCVRFile(null);
           cdb.setCVRsImported(0);
           if (the_failure_flag) {
-            cdb.setCVRImportStatus(ImportStatus.FAILED);
+            cdb.setCVRImportStatus(new ImportStatus(ImportState.FAILED, the_failure_message));
           }
           Persistence.commitTransaction();
           success = true;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -23,15 +23,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
 import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -45,6 +46,7 @@ import javax.persistence.Table;
 import javax.persistence.Version;
 
 import us.freeandfair.corla.model.CVRContestInfo.ConsensusValue;
+import us.freeandfair.corla.model.ImportStatus.ImportState;
 import us.freeandfair.corla.persistence.AuditSelectionIntegerMapConverter;
 import us.freeandfair.corla.persistence.PersistentEntity;
 
@@ -132,9 +134,17 @@ public class CountyDashboard implements PersistentEntity {
   /**
    * The CVR import status.
    */
-  @Column(nullable = false)
-  @Enumerated(EnumType.STRING)
-  private ImportStatus my_cvr_import_status = ImportStatus.NOT_ATTEMPTED;
+  @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "my_import_state",
+                         column = @Column(name = "cvr_import_state")),
+      @AttributeOverride(name = "my_error_message",
+                         column = @Column(name = "cvr_import_error_message")),
+      @AttributeOverride(name = "my_timestamp",
+                         column = @Column(name = "cvr_import_timestamp"))
+  })
+  private ImportStatus my_cvr_import_status = 
+      new ImportStatus(ImportState.NOT_ATTEMPTED, null);
   
   /**
    * The timestamp of the most recent uploaded ballot manifest. 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -142,7 +142,7 @@ public class CountyDashboard implements PersistentEntity {
                          column = @Column(name = "cvr_import_error_message")),
       @AttributeOverride(name = "my_timestamp",
                          column = @Column(name = "cvr_import_timestamp"))
-  })
+      })
   private ImportStatus my_cvr_import_status = 
       new ImportStatus(ImportState.NOT_ATTEMPTED, null);
   

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ImportStatus.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ImportStatus.java
@@ -11,15 +11,119 @@
 
 package us.freeandfair.corla.model;
 
+import java.io.Serializable;
+import java.time.Instant;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
 /**
- * The possible statuses for a file import.
+ * Status information for a file import.
  * 
  * @author Daniel M. Zimmerman <dmz@freeandfair.us>
  * @version 1.0.0
  */
-public enum ImportStatus {
+@Embeddable
+//this class has many fields that would normally be declared final, but
+//cannot be for compatibility with Hibernate and JPA.
+@SuppressWarnings("PMD.ImmutableField")
+public class ImportStatus implements Serializable {
+  /**
+   * The serialVersionUID.
+   */
+  private static final long serialVersionUID = 1L;
+  
+  /**
+   * The import state.
+   */
+  @Enumerated(EnumType.STRING)
+  private ImportState my_import_state;
+  
+  /**
+   * The error message, if any.
+   */
+  private String my_error_message;
+  
+  /**
+   * The timestamp of the status update.
+   */
+  private Instant my_timestamp;
+  
+  /**
+   * Constructs an empty ImportStatus, solely for persistence.
+   */
+  public ImportStatus() {
+    super();
+  }
+  
+  /**
+   * Constructs a new ImportStatus with the specified contents.
+   * 
+   * @param the_import_state The import state.
+   * @param the_error_message The error message, or null if there has been no error.
+   * @param the_timestamp The timestamp.
+   */
+  public ImportStatus(final ImportState the_import_state,
+                      final String the_error_message,
+                      final Instant the_timestamp) {
+    my_import_state = the_import_state;
+    my_error_message = the_error_message;
+    my_timestamp = the_timestamp;
+  }
+  
+  /**
+   * Constructs a new ImportStatus with the specified contents, using the
+   * current time as a timestamp.
+   * 
+   * @param the_import_state The import state.
+   * @param the_error_message The error message, or null if there has been no error.
+   */
+  public ImportStatus(final ImportState the_import_state,
+                      final String the_error_message) {
+    this(the_import_state, the_error_message, Instant.now());
+  }
+  
+  /**
+   * Constructs a new ImportStatus with the specified import state, no error
+   * message, and the current time as a timestamp.
+   * 
+   * @param the_import_state The import state.
+   * @param the_error_message The error message, or null if there has been no error.
+   */
+  public ImportStatus(final ImportState the_import_state) {
+    this(the_import_state, null, Instant.now());
+  }
+ 
+  /**
+   * @return the import state.
+   */
+  public ImportState importState() {
+    return my_import_state;
+  }
+  
+  /**
+   * @return the error message.
+   */
+  public String errorMessage() {
+    return my_error_message;
+  }
+  
+  /**
+   * @return the timestamp.
+   */
+  public Instant timestamp() {
+    return my_timestamp;
+  }
+  
+  /**
+   * The state of an import.
+   */
+  public enum ImportState {
     NOT_ATTEMPTED,
     IN_PROGRESS,
     SUCCESSFUL,
     FAILED;
+  }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ImportStatus.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ImportStatus.java
@@ -14,7 +14,6 @@ package us.freeandfair.corla.model;
 import java.io.Serializable;
 import java.time.Instant;
 
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;


### PR DESCRIPTION
This changes the import status on the county dashboard from a single enum value to a structure with an enum value, a timestamp, and an error message. It also changes the result of the import endpoint to be the import start time.