### PR TITLE
CVR import notifications

### DIFF
--- a/client/action.d.ts
+++ b/client/action.d.ts
@@ -1,6 +1,8 @@
 declare namespace Action {
     type App
-        = CountyDashboardRefreshOk
+        = CountyCVRImportFailNotice
+        | CountyCVRImportOkNotice
+        | CountyDashboardRefreshOk
         | CountyFetchContestsOk
         | CountyFetchCvrOk
         | CountyLoginOk
@@ -11,6 +13,7 @@ declare namespace Action {
         | FetchCountyASMStateOk
         | FetchCvrsToAuditOk
         | FetchDOSASMStateOk
+        | ImportCvrExportOk
         | Login1FOk
         | SelectContestsForAuditOk
         | UpdateAcvrForm
@@ -20,6 +23,16 @@ declare namespace Action {
         | UploadRandomSeedOk
         | UploadingBallotManifest
         | UploadingCvrExport;
+
+    interface CountyCVRImportFailNotice {
+        type: 'COUNTY_CVR_IMPORT_FAIL_NOTICE';
+        data: any;
+    }
+
+    interface CountyCVRImportOkNotice {
+        type: 'COUNTY_CVR_IMPORT_OK_NOTICE';
+        data: any;
+    }
 
     interface CountyDashboardRefreshOk {
         type: 'COUNTY_DASHBOARD_REFRESH_OK';
@@ -73,6 +86,11 @@ declare namespace Action {
 
     interface FetchDOSASMStateOk {
         type: 'FETCH_DOS_ASM_STATE_OK';
+        data: any;
+    }
+
+    interface ImportCvrExportOk {
+        type: 'IMPORT_CVR_EXPORT_OK';
         data: any;
     }
 

--- a/client/county.d.ts
+++ b/client/county.d.ts
@@ -16,7 +16,7 @@ declare namespace County {
         cvrExport?: UploadedFile;
         cvrExportCount?: number;
         cvrExportHash?: string;
-        cvrImportAlert: CVRImportAlert;
+        cvrImportPending: CVRImportPending;
         cvrImportStatus: CVRImportStatus;
         cvrsToAudit?: JSON.CVR[];  // Sic
         disagreementCount?: number;
@@ -31,6 +31,11 @@ declare namespace County {
         type: 'County';
         uploadingBallotManifest?: boolean;
         uploadingCVRExport?: boolean;
+    }
+
+    interface CVRImportPending {
+        alerted: boolean;
+        started: Date;
     }
 
     interface CVRImportStatus {

--- a/client/county.d.ts
+++ b/client/county.d.ts
@@ -33,6 +33,18 @@ declare namespace County {
         uploadingCVRExport?: boolean;
     }
 
+    interface CVRImportStatus {
+        error?: string;
+        state: CVRImportState;
+        timestamp: Date;
+    }
+
+    type CVRImportState
+        = 'NOT_ATTEMPTED'
+        | 'IN_PROGRESS'
+        | 'SUCCESSFUL'
+        | 'FAILED';
+
     type CVRImportAlert = 'None' | 'Fail' | 'Ok';
 
     interface ASMStates {

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -112,12 +112,6 @@ type CountyDashboardStatus
     | 'CVRS_UPLOADED_SUCCESSFULLY'
     | 'ERROR_IN_UPLOADED_DATA';
 
-type CVRImportStatus
-    = 'NOT_ATTEMPTED'
-    | 'IN_PROGRESS'
-    | 'SUCCESSFUL'
-    | 'FAILED';
-
 interface Round {
     actualCount: number;
     disagreements: number;

--- a/client/json.d.ts
+++ b/client/json.d.ts
@@ -69,6 +69,12 @@ declare namespace JSON {
         status: CountyDashboardStatus;
     }
 
+    interface CVRImportStatus {
+        error_message?: string;
+        import_state: County.CVRImportState;
+        timestamp: string;
+    }
+
     interface ContestChoice {
         name: string;
         description: string;

--- a/client/src/adapter/countyDashboardRefresh.ts
+++ b/client/src/adapter/countyDashboardRefresh.ts
@@ -128,6 +128,14 @@ function parseFile(file: JSON.UploadedFile): Option<UploadedFile> {
     };
 }
 
+function parseCVRImportStatus(data: JSON.CVRImportStatus): County.CVRImportStatus {
+    return {
+        error: data.error_message,
+        state: data.import_state,
+        timestamp: new Date(data.timestamp),
+    };
+}
+
 export function parse(data: JSON.CountyDashboard, state: County.AppState) {
     const findContest = (id: number) => state.contestDefs![id];
 
@@ -146,7 +154,7 @@ export function parse(data: JSON.CountyDashboard, state: County.AppState) {
         currentRound: data.current_round ? parseRound(data.current_round) : null,
         cvrExport: parseFile(data.cvr_export_file),
         cvrExportCount: data.cvr_export_count,
-        cvrImportStatus: data.cvr_import_status,
+        cvrImportStatus: parseCVRImportStatus(data.cvr_import_status),
         disagreementCount: parseDisCount(data.disagreement_count),
         discrepancyCount: parseDisCount(data.discrepancy_count),
         election: parseElection(data),

--- a/client/src/component/County/Dashboard/CVRExport/Uploading.tsx
+++ b/client/src/component/County/Dashboard/CVRExport/Uploading.tsx
@@ -56,7 +56,7 @@ const Uploading = (props: UploadingProps) => {
         return <UploadingFile />;
     }
 
-    if (cvrImportStatus === 'IN_PROGRESS') {
+    if (cvrImportStatus.state === 'IN_PROGRESS') {
         return (
             <div className='pt-card'>
                 <Progress file={ cvrExport } count={ cvrExportCount } />

--- a/client/src/component/County/Dashboard/CVRExport/Uploading.tsx
+++ b/client/src/component/County/Dashboard/CVRExport/Uploading.tsx
@@ -32,6 +32,15 @@ const Progress = (props: ProgressProps) => {
     );
 };
 
+const UploadingFile = () => {
+    return (
+        <div className='pt-card'>
+            <Spinner className='pt-large' intent={ Intent.PRIMARY } />
+            <div>Uploading file...</div>
+        </div>
+    );
+};
+
 interface UploadingProps {
     countyState: County.AppState;
 }
@@ -40,9 +49,12 @@ const Uploading = (props: UploadingProps) => {
     const { countyState } = props;
     const { cvrExportCount, cvrExport, cvrImportStatus } = countyState;
 
-    if (!cvrExportCount) { return null; }
-    if (!cvrExport) { return null; }
-    if (!cvrImportStatus) { return null; }
+    if (!cvrExportCount) {
+        return <UploadingFile />;
+    }
+    if (!cvrExport) {
+        return <UploadingFile />;
+    }
 
     if (cvrImportStatus === 'IN_PROGRESS') {
         return (
@@ -51,12 +63,7 @@ const Uploading = (props: UploadingProps) => {
             </div>
         );
     } else {
-        return (
-            <div className='pt-card'>
-                <Spinner className='pt-large' intent={ Intent.PRIMARY } />
-                <div>Uploading file...</div>
-            </div>
-        );
+        return <UploadingFile />;
     }
 };
 

--- a/client/src/reducer/county/dashboardRefreshOk.ts
+++ b/client/src/reducer/county/dashboardRefreshOk.ts
@@ -4,14 +4,14 @@ import { parse } from 'corla/adapter/countyDashboardRefresh';
 
 
 function cvrImportAlert(
-    prev: CVRImportStatus,
-    next: CVRImportStatus,
+    prev: County.CVRImportStatus,
+    next: County.CVRImportStatus,
 ): County.CVRImportAlert {
-    if (prev === 'IN_PROGRESS') {
-        if (next === 'FAILED') {
+    if (prev.state === 'IN_PROGRESS') {
+        if (next.state === 'FAILED') {
             return 'Fail';
         }
-        if (next === 'SUCCESSFUL') {
+        if (next.state === 'SUCCESSFUL') {
             return 'Ok';
         }
     }

--- a/client/src/reducer/county/dashboardRefreshOk.ts
+++ b/client/src/reducer/county/dashboardRefreshOk.ts
@@ -3,23 +3,6 @@ import { isEmpty, merge } from 'lodash';
 import { parse } from 'corla/adapter/countyDashboardRefresh';
 
 
-function cvrImportAlert(
-    prev: County.CVRImportStatus,
-    next: County.CVRImportStatus,
-): County.CVRImportAlert {
-    if (prev.state === 'IN_PROGRESS') {
-        if (next.state === 'FAILED') {
-            return 'Fail';
-        }
-        if (next.state === 'SUCCESSFUL') {
-            return 'Ok';
-        }
-    }
-
-    return 'None';
-}
-
-
 export default function dashboardRefreshOk(
     state: County.AppState,
     action: Action.CountyDashboardRefreshOk,
@@ -33,11 +16,6 @@ export default function dashboardRefreshOk(
     // rounds.
     nextState.auditBoard = newState.auditBoard;
     nextState.currentRound = newState.currentRound;
-
-    nextState.cvrImportAlert = cvrImportAlert(
-        state.cvrImportStatus,
-        newState.cvrImportStatus,
-    );
 
     return nextState;
 }

--- a/client/src/reducer/defaultState.ts
+++ b/client/src/reducer/defaultState.ts
@@ -7,7 +7,10 @@ export function countyState(): County.AppState {
         },
         auditBoard: [],
         contests: [],
-        cvrImportAlert: 'None',
+        cvrImportPending: {
+            alerted: false,
+            started: new Date(),
+        },
         cvrImportStatus: {
             state: 'NOT_ATTEMPTED',
             timestamp: new Date(),

--- a/client/src/reducer/defaultState.ts
+++ b/client/src/reducer/defaultState.ts
@@ -8,7 +8,10 @@ export function countyState(): County.AppState {
         auditBoard: [],
         contests: [],
         cvrImportAlert: 'None',
-        cvrImportStatus: 'NOT_ATTEMPTED',
+        cvrImportStatus: {
+            state: 'NOT_ATTEMPTED',
+            timestamp: new Date(),
+        },
         rounds: [],
         type: 'County',
     };

--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -71,6 +71,16 @@ export default function root(state: AppState, action: Action.App) {
         return fetchDOSASMStateOk(state as DOS.AppState, action);
     }
 
+    case 'IMPORT_CVR_EXPORT_OK': {
+        const nextState = { ...state } as County.AppState;
+
+        const data = action.data.received;
+        nextState.cvrImportPending.alerted = false;
+        nextState.cvrImportPending.started = new Date(data.import_start_time);
+
+        return nextState;
+    }
+
     case 'LOGIN_1F_OK': {
         return login1FOk(state as LoginAppState, action);
     }
@@ -101,6 +111,22 @@ export default function root(state: AppState, action: Action.App) {
 
     case 'UPLOADING_CVR_EXPORT': {
         return uploadingCvrExport(state as County.AppState, action);
+    }
+
+    case 'COUNTY_CVR_IMPORT_FAIL_NOTICE': {
+        const nextState = { ...state } as County.AppState;
+
+        nextState.cvrImportPending.alerted = true;
+
+        return nextState;
+    }
+
+    case 'COUNTY_CVR_IMPORT_OK_NOTICE': {
+        const nextState = { ...state } as County.AppState;
+
+        nextState.cvrImportPending.alerted = true;
+
+        return nextState;
     }
 
     default:


### PR DESCRIPTION
Fixes a bug where we would alert users about re-uploads, but not initial uploads. Also re-ensures we include what went wrong if we can (e.g. illegal header in a CVR file).