### PR TITLE
Fix multiple server issues

### DIFF
--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>us.freeandfair.production</groupId>
 	<artifactId>colorado_rla</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.5-dev</version>
 	<name>ColoradoRLA</name>
 	<description>A risk-limiting audit system for the State of Colorado</description>
 	<properties>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/BallotManifestImport.java
@@ -91,6 +91,13 @@ public class BallotManifestImport extends AbstractCountyDashboardEndpoint {
     if (cdb == null) {
       serverError(the_response, "could not locate county dashboard");
     } else {
+      // mark any previous ballot manifest import as NOT_IMPORTED
+      if (cdb.manifestFile() != null) {
+        cdb.manifestFile().setStatus(FileStatus.NOT_IMPORTED);
+        Persistence.saveOrUpdate(cdb.cvrFile());
+      }
+
+      // now set the new manifest info
       cdb.setManifestFile(the_file);
       cdb.setBallotsInManifest(the_ballot_count);
       try {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
@@ -232,7 +232,9 @@ public class CVRAuditInfo implements PersistentEntity {
    */
   public void setDiscrepancy(final Set<AuditReason> the_reasons) {
     my_discrepancy.clear();
-    my_discrepancy.addAll(the_reasons);
+    if (the_reasons != null) {
+      my_discrepancy.addAll(the_reasons);
+    }
   }
   
   /**
@@ -250,7 +252,9 @@ public class CVRAuditInfo implements PersistentEntity {
    */
   public void setDisagreement(final Set<AuditReason> the_reasons) {
     my_disagreement.clear();
-    my_disagreement.addAll(the_reasons);
+    if (the_reasons != null) {
+      my_disagreement.addAll(the_reasons);
+    }
   }
   
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -197,17 +197,17 @@ public final class Persistence {
       
       // C3P0 connection pooling
       settings.put(Environment.C3P0_MIN_SIZE, 
-                   system_properties.getProperty("hibernate.c3p0.min_size", ""));
+                   system_properties.getProperty("hibernate.c3p0.min_size", "20"));
       settings.put(Environment.C3P0_MAX_SIZE, 
-                   system_properties.getProperty("hibernate.c3p0.max_size", ""));
+                   system_properties.getProperty("hibernate.c3p0.max_size", "20"));
       settings.put(Environment.C3P0_IDLE_TEST_PERIOD,
-                   system_properties.getProperty("hibernate.c3p0.idle_test_period", ""));
+                   system_properties.getProperty("hibernate.c3p0.idle_test_period", "0"));
       settings.put(Environment.C3P0_MAX_STATEMENTS, 
-                   system_properties.getProperty("hibernate.c3p0.max_statements", ""));
+                   system_properties.getProperty("hibernate.c3p0.max_statements", "0"));
       settings.put(Environment.C3P0_TIMEOUT, 
-                   system_properties.getProperty("hibernate.c3p0.timeout", ""));
+                   system_properties.getProperty("hibernate.c3p0.timeout", "300"));
       settings.put("hibernate.c3p0.numHelperThreads", 
-                   system_properties.getProperty("hibernate.c3p0.numHelperThreads", ""));
+                   system_properties.getProperty("hibernate.c3p0.numHelperThreads", "3"));
       settings.put("hibernate.c3p0.privilegeSpawnedThreads", TRUE);
       settings.put("hibernate.c3p0.contextClassLoaderSource", "none");
       
@@ -217,11 +217,11 @@ public final class Persistence {
       
       // sql debugging
       settings.put(Environment.SHOW_SQL, 
-                   system_properties.getProperty("hibernate.show_sql", ""));
+                   system_properties.getProperty("hibernate.show_sql", FALSE));
       settings.put(Environment.FORMAT_SQL, 
-                   system_properties.getProperty("hibernate.format_sql", ""));
+                   system_properties.getProperty("hibernate.format_sql", FALSE));
       settings.put(Environment.USE_SQL_COMMENTS, 
-                   system_properties.getProperty("hibernate.use_sql_comments", ""));
+                   system_properties.getProperty("hibernate.use_sql_comments", FALSE));
       
       // table and column naming
       settings.put(Environment.PHYSICAL_NAMING_STRATEGY, 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -206,8 +206,11 @@ public final class Persistence {
                    system_properties.getProperty("hibernate.c3p0.max_statements", ""));
       settings.put(Environment.C3P0_TIMEOUT, 
                    system_properties.getProperty("hibernate.c3p0.timeout", ""));
+      settings.put("hibernate.c3p0.numHelperThreads", 
+                   system_properties.getProperty("hibernate.c3p0.numHelperThreads", ""));
       settings.put("hibernate.c3p0.privilegeSpawnedThreads", TRUE);
       settings.put("hibernate.c3p0.contextClassLoaderSource", "none");
+      
       // automatic schema generation
       settings.put(Environment.HBM2DDL_AUTO, 
                    system_properties.getProperty("hibernate.hbm2ddl.auto", ""));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CVRAuditInfoQueries.java
@@ -188,6 +188,7 @@ public final class CVRAuditInfoQueries {
                                       subroot2.get(MY_INDEX))));
       cq.select(root);
       cq.where(cb.and(cb.equal(root.get(MY_INDEX), sq1),
+                      cb.equal(root.get(MY_DASHBOARD), the_dashboard),
                       cb.not(cb.exists(sq2))));
       cq.orderBy(cb.asc(root.get(MY_INDEX)));
       final TypedQuery<CVRAuditInfo> query = s.createQuery(cq);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.TimeZone;
 
 import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
@@ -282,7 +282,7 @@ public class CountyReport {
     cell.setCellValue("Generated " + 
                       DATE_TIME_FORMATTER.
                       format(LocalDateTime.ofInstant(my_timestamp,
-                                                     ZoneOffset.systemDefault())));
+                                                     TimeZone.getDefault().toZoneId())));
     
     row = summary_sheet.createRow(row_number++);
     cell_number = 0;
@@ -840,7 +840,7 @@ public class CountyReport {
     final LocalDateTime election_datetime = 
         LocalDateTime.ofInstant(my_dosdb.auditInfo().electionDate(), ZoneOffset.UTC);
     final LocalDateTime report_datetime = 
-        LocalDateTime.ofInstant(my_timestamp, ZoneId.systemDefault()).
+        LocalDateTime.ofInstant(my_timestamp, TimeZone.getDefault().toZoneId()).
         truncatedTo(ChronoUnit.SECONDS);
     final StringBuilder sb = new StringBuilder(32);
     

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -30,6 +29,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.OptionalInt;
 import java.util.SortedMap;
+import java.util.TimeZone;
 import java.util.TreeMap;
 
 import org.apache.poi.ss.usermodel.BorderStyle;
@@ -211,7 +211,7 @@ public class StateReport {
     cell.setCellValue("Generated " + 
                       DATE_TIME_FORMATTER.
                       format(LocalDateTime.ofInstant(my_timestamp,
-                                                     ZoneOffset.systemDefault())));
+                                                     TimeZone.getDefault().toZoneId())));
     
     row = summary_sheet.createRow(row_number++);
     cell_number = 0;
@@ -746,7 +746,7 @@ public class StateReport {
     final LocalDateTime election_datetime = 
         LocalDateTime.ofInstant(my_dosdb.auditInfo().electionDate(), ZoneOffset.UTC);
     final LocalDateTime report_datetime = 
-        LocalDateTime.ofInstant(my_timestamp, ZoneId.systemDefault()).
+        LocalDateTime.ofInstant(my_timestamp, TimeZone.getDefault().toZoneId()).
         truncatedTo(ChronoUnit.SECONDS);
     final StringBuilder sb = new StringBuilder(32);
 


### PR DESCRIPTION
Addresses multiple issues:
- null pointer exception on "unaudit" action (#858)
- inexact CVR query for listing CVRs in county/state reports
- class loading problems using the ZoneId class at runtime
- ballot manifest files that are replaced by subsequent imports not being reset to NOT_IMPORTED

Closes #848 
Closes #858 
(though the client bug that triggered #858 probably has to be addressed too)
