### PR TITLE
Async crtest upload

### DIFF
--- a/test/smoketest/main.py
+++ b/test/smoketest/main.py
@@ -373,7 +373,7 @@ def get_imported_count(dashboard):
         approximate_record_count = 0
 
     return (dashboard['asm_state'],
-            "Received about %d of about %d CVRs" %
+            "Parsed about %d of about %d CVRs" %
                 (imported_count, approximate_record_count))
 
 


### PR DESCRIPTION
Support async upload
-f is normal path now, not relative to __file__ of executable
import sampler only when used: easier to deploy basic functionality